### PR TITLE
Fix 37 annotation titles empty

### DIFF
--- a/data/locale/edirom-lang-de.xml
+++ b/data/locale/edirom-lang-de.xml
@@ -151,6 +151,7 @@
         <entry key="drag-and-drop" value="Drag-and-Drop"/>
         <entry key="comboBox" value="Kombobox"/>
         <entry key="views" value="Ansichten"/>
+        <entry key="no_title" value="[Kein Titel gefunden!]"/>
         <entry key="window.minimize" value="minimieren"/>
         <entry key="window.maximize" value="maximieren"/>
         <entry key="view.window.source.SourceView_zoomSlider" value="Schieber für Zoom"/>

--- a/data/locale/edirom-lang-en.xml
+++ b/data/locale/edirom-lang-en.xml
@@ -39,7 +39,7 @@
         <entry key="controller.window.Window_searchView" value="Search window"/>
         <entry key="controller.window.Window_sourceView" value="Facsimile"/>
         <entry key="controller.window.Window_audioView" value="Audio"/>
-	<entry key="controller.window.Window_verovioView" value="Rendering"/>
+	    <entry key="controller.window.Window_verovioView" value="Rendering"/>
         <entry key="controller.window.Window_summaryView" value="Summary"/>
         <entry key="controller.window.Window_textFacsimileSplitView" value="Text-Facsimile"/>
         <entry key="controller.window.Window_textView" value="Text"/>
@@ -151,6 +151,7 @@
         <entry key="drag-and-drop" value="drag-and-drop"/>
         <entry key="comboBox" value="combo box"/>
         <entry key="views" value="Views"/>
+        <entry key="no_title" value="[No title found!]"/>
         <entry key="window.minimize" value="minimize"/>
         <entry key="window.maximize" value="maximize"/>
         <entry key="view.window.source.SourceView_zoomSlider" value="Zoom Slider"/>

--- a/data/xql/getAnnotation.xql
+++ b/data/xql/getAnnotation.xql
@@ -478,15 +478,17 @@ return
             </div>
             <div class="contentBox">
                 {
-                    if ($annot/mei:annot) then (
-                        for $a in $annot/mei:annot
+                    for $a in (if($annot/mei:annot) then ($annot/mei:annot) else ($annot))
+                        
+                        let $title := eutil:getLocalizedTitle($annot, $lang, '')
+
                         return (
-                            <h1>{eutil:getLocalizedTitle($annot, $lang)}</h1>,
-                            annotation:getContent($a, '', $edition)
-                        )
-                    ) else (
-                        (<h1>{eutil:getLocalizedTitle($annot, $lang)}</h1>,
-                        annotation:getContent($annot, '', $edition))
+                            if ($title!='') then (
+                                <h1>{$title}</h1>,
+                                annotation:getContent($a, '', $edition)
+                            ) else (
+                                annotation:getContent($a, '', $edition)
+                            )
                         )
                 }
             </div>

--- a/data/xqm/eutil.xqm
+++ b/data/xqm/eutil.xqm
@@ -95,6 +95,7 @@ declare function eutil:getLocalizedName($node, $lang) {
 
 };
 
+
 (:~
  : Returns a localized string
  :
@@ -103,6 +104,19 @@ declare function eutil:getLocalizedName($node, $lang) {
  : @return The string (normalized space)
  :)
 declare function eutil:getLocalizedTitle($node as node(), $lang as xs:string?) as xs:string {
+
+    eutil:getLocalizedTitle($node, $lang, eutil:getLanguageString('no_title', ()))
+
+};
+
+(:~
+ : Returns a localized string
+ :
+ : @param $node The node to be processed
+ : @param $lang Optional parameter for lang selection
+ : @return The string (normalized space)
+ :)
+declare function eutil:getLocalizedTitle($node as node(), $lang as xs:string?, $default as xs:string) as xs:string {
 
     let $namespace := eutil:getNamespace($node)
   
@@ -125,8 +139,8 @@ declare function eutil:getLocalizedTitle($node as node(), $lang as xs:string?) a
             ($titleMEI)
         else if ($namespace = 'tei' and $titleTEI != '') then
             ($titleTEI)
-        else
-            ('[No title found!]')
+        else 
+            $default
 
 };
 


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
Titles in annotation boxes were showing "[No title found!]" when there is no text for a title. Now no title is displayed instead

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
closes #37 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
Build and deployed the open Klarinettenquintett and have a look at the Autograph annotations.

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- New feature (non-breaking change which adds functionality)
- Improvement

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Backend/blob/develop/CONTRIBUTING.md) document.
- I have added tests to cover my changes at [testing](https://github.com/Edirom/Edirom-Online-Backend/tree/develop/testing)
- All new and existing tests passed.
