### PR TITLE
adding host for image resolving

### DIFF
--- a/data/xql/getHelp.xql
+++ b/data/xql/getHelp.xql
@@ -30,6 +30,7 @@ let $contextPath := if(starts-with(document-uri($doc), '/db'))
                     else document-uri($doc)
 let $contextPath := substring-before($contextPath, concat('help/help_', $lang, '.xml'))
 let $contextPath := request:get-context-path() || $contextPath
+let $host := request:get-scheme() || '://' || request:get-hostname() || ':' || request:get-server-port()
 
 let $xsl := doc('../xslt/edirom_langReplacement.xsl')
 let $doc := 
@@ -47,7 +48,8 @@ let $doc :=
             <param name="base" value="{concat($base, '/../xslt/')}"/>
             <param name="lang" value="{$lang}"/>
             <param name="tocDepth" value="1"/>
-            <param name="contextPath" value="{$contextPath}"/>
+            (: == passing empty value for docUri (XSLT expects xs:anyURI, but ExtJS view does not provide value) -> github#480 == :)
+            <param name="contextPath" value="{$host}{$contextPath}"/>
             (: == passing empty value for docUri (XSLT expects xs:anyURI, but ExtJS view does not provide value) -> github#480 == :)
             <param name="docUri" value="''"/>
         </parameters>

--- a/data/xslt/tei/profiles/edirom-body/teiBody2HTML.xsl
+++ b/data/xslt/tei/profiles/edirom-body/teiBody2HTML.xsl
@@ -163,7 +163,9 @@
                     <!-- url starts with http i.e. points to a web accessible location -->
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:value-of select="$contextPath || '/' || substring-after(functx:substring-before-last($docUri, '/'), 'xmldb:exist:///db/') || '/'"/>
+                    <xsl:value-of select="replace(
+                    concat($contextPath, '/', substring-after(functx:substring-before-last($docUri, '/'), 'xmldb:exist:///db/'), '/'),
+                    '/+$', '/')"/>
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:variable>


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
The images in the help window were not loading due to frontend/backend separation and relative image paths.
This is solved now by dynamically reading the host, and providing the host in the image url.

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Fixes #58 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
In Edirom-Online repository clone:

```
git checkout develop && \
git pull && \
docker compose down --volumes --remove-orphans && \
export BE_BRANCH=fix-help-images-not-loading && \
export EDITION_XAR=https://github.com/Edirom/EditionExample/releases/download/v0.1.1/EditionExample-0.1.1.xar && \
docker compose build --no-cache && \
docker compose up -d \
```

Then at http://localhost:8089/ click the "Help / Question mark" button. See if images are loaded.

Afterwards, reset the env variables again:

```
unset BE_BRANCH && unset EDITION_XAR
```

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Backend/blob/develop/CONTRIBUTING.md) document.