### PR TITLE
Ftr/dynamic annotation classification

### DIFF
--- a/data/locale/edirom-lang-de.xml
+++ b/data/locale/edirom-lang-de.xml
@@ -73,6 +73,7 @@
         <entry key="view.desktop.TaskBar_Sort_vertical" value="Übereinander anordnen" />
         <entry key="view.desktop.TaskBar_Sort_horizontal" value="Nebeneinander anordnen" />
         <entry key="view.desktop.TopBar_homeBtnLabel" value="Edirom Online"/>
+
         <entry key="view.window.AnnotationView_Title" value="Anmerkungen"/>
         <entry key="view.window.AnnotationView_No" value="Nr."/>
         <entry key="view.window.AnnotationView_TitleLabel" value="Titel"/>
@@ -90,11 +91,11 @@
         <entry key="view.window.AnnotationView_Grid" value="Rasteransicht"/>
         <entry key="view.window.AnnotationView_Single" value="Einzelansicht"/>
         <entry key="view.window.AnnotationView_ListView" value="Listenansicht"/>
-
         <entry key="view.window.AnnotationView_PreviousAnnotation" value="Vorherige Anmerkung"/>
         <entry key="view.window.AnnotationView_NextAnnotation" value="Nächste Anmerkung"/>
         <entry key="view.window.AnnotationView_OpenAll" value="Alle Quellen öffnen"/>
         <entry key="view.window.AnnotationView_CloseAll" value="Alle Quellen schließen"/>
+
         <entry key="view.window.HelpWindow_Title" value="Hilfe"/>
         <entry key="view.window.TopBar_View" value="Ansicht"/>
 

--- a/data/locale/edirom-lang-de.xml
+++ b/data/locale/edirom-lang-de.xml
@@ -77,9 +77,9 @@
         <entry key="view.window.AnnotationView_Title" value="Anmerkungen"/>
         <entry key="view.window.AnnotationView_No" value="Nr."/>
         <entry key="view.window.AnnotationView_TitleLabel" value="Titel"/>
-        <entry key="view.window.AnnotationView_Categories" value="Kategorien"/>
-        <entry key="view.window.AnnotationView_ediromCategory" value="Kategorie"/>
-        <entry key="view.window.AnnotationView_ediromPriority" value="Priorität"/>
+        <entry key="ediromCategory_multiple" value="Kategorien"/>
+        <entry key="ediromCategory" value="Kategorie"/>
+        <entry key="ediromPriority" value="Priorität"/>
         <entry key="view.window.AnnotationView_Participants" value="Subjekte"/>
         <entry key="view.window.AnnotationView_Source" value="Quelle"/>
         <entry key="view.window.AnnotationView_Sources" value="Quellen"/>

--- a/data/locale/edirom-lang-de.xml
+++ b/data/locale/edirom-lang-de.xml
@@ -78,8 +78,8 @@
         <entry key="view.window.AnnotationView_No" value="Nr."/>
         <entry key="view.window.AnnotationView_TitleLabel" value="Titel"/>
         <entry key="view.window.AnnotationView_Categories" value="Kategorien"/>
-        <entry key="view.window.AnnotationView_Category" value="Kategorie"/>
-        <entry key="view.window.AnnotationView_Priority" value="Priorität"/>
+        <entry key="view.window.AnnotationView_ediromCategory" value="Kategorie"/>
+        <entry key="view.window.AnnotationView_ediromPriority" value="Priorität"/>
         <entry key="view.window.AnnotationView_Participants" value="Subjekte"/>
         <entry key="view.window.AnnotationView_Source" value="Quelle"/>
         <entry key="view.window.AnnotationView_Sources" value="Quellen"/>

--- a/data/locale/edirom-lang-de.xml
+++ b/data/locale/edirom-lang-de.xml
@@ -23,16 +23,16 @@
     <lang>de</lang>
     <version>1.0</version>
     <entries>
-        
+
         <!-- *** APPLICATION-UI *** -->
-        
+
         <entry key="global_cancel" value="Abbrechen"/>
         <entry key="global_execute" value="Ausführen"/>
         <entry key="global_loading" value="Lade…"/>
         <entry key="global_unknown" value="Unbekannt"/>
-        
+
         <entry key="controller.desktop.TaskBar_confirmReload" value="Die Anwendung muss neu gestartet werden, damit die Spracheinstellung vollständig umgesetzt wird."/>
-        
+
         <entry key="controller.window.Window_annotationView" value="Anmerkung"/>
         <entry key="controller.window.Window_headerView" value="Metadaten"/>
         <entry key="controller.window.Window_renderingView" value="Rendering"/>
@@ -45,7 +45,7 @@
         <entry key="controller.window.Window_textView" value="Text"/>
         <entry key="controller.window.Window_xmlView" value="XML-Ansicht"/>
         <entry key="controller.window.Window_iFrameView" value="HTML-Ansicht"/>
-        
+
         <entry key="view.desktop.Desktop_Cascade" value="Überlappen"/>
         <entry key="view.desktop.Desktop_Close" value="Schließen"/>
         <entry key="view.desktop.Desktop_CloseAll" value="Schließe alle"/>
@@ -54,7 +54,7 @@
         <entry key="view.desktop.Desktop_Minimize" value="Minimieren"/>
         <entry key="view.desktop.Desktop_Restore" value="Wiederherstellen"/>
         <entry key="view.desktop.Desktop_Tile" value="Nebeneinander"/>
-        
+
         <entry key="view.desktop.TaskBar_concordanceNav" value="Öffne Konkordanznavigator"/>
         <entry key="view.desktop.TaskBar_measureNumbers" value="Taktzahlen ein-/ausblenden"/>
         <entry key="view.desktop.TaskBar_showMeasures" value="Taktzahlen ein-/ausblenden (global)"/>
@@ -90,24 +90,24 @@
         <entry key="view.window.AnnotationView_Grid" value="Rasteransicht"/>
         <entry key="view.window.AnnotationView_Single" value="Einzelansicht"/>
         <entry key="view.window.AnnotationView_ListView" value="Listenansicht"/>
-        
+
         <entry key="view.window.AnnotationView_PreviousAnnotation" value="Vorherige Anmerkung"/>
         <entry key="view.window.AnnotationView_NextAnnotation" value="Nächste Anmerkung"/>
         <entry key="view.window.AnnotationView_OpenAll" value="Alle Quellen öffnen"/>
         <entry key="view.window.AnnotationView_CloseAll" value="Alle Quellen schließen"/>
         <entry key="view.window.HelpWindow_Title" value="Hilfe"/>
         <entry key="view.window.TopBar_View" value="Ansicht"/>
-        
+
         <entry key="view.window.concordanceNavigator.ConcordanceNavigator_Title" value="Konkordanzen"/>
         <entry key="view.window.concordanceNavigator.ConcordanceNavigator_Show" value="Anzeigen"/>
-        
+
         <entry key="view.window.search.SearchWindow_Title" value="Suche"/>
         <entry key="view.window.search.SearchWindow_Hit" value="Treffer"/>
         <entry key="view.window.search.SearchWindow_Hits" value="Treffer"/>
         <entry key="view.window.search.SearchWindow_NoHit" value="Kein Treffer gefunden"/>
         <entry key="view.window.search.SearchWindow_NoHits" value="Keine Treffer gefunden"/>
         <entry key="view.window.search.SearchWindow_HitsIn" value="Treffer gefunden in"/>
-        <entry key="view.window.search.SearchWindow_ShowAllHits" value="Alle Treffer zeigen"/>   
+        <entry key="view.window.search.SearchWindow_ShowAllHits" value="Alle Treffer zeigen"/>
         <entry key="view.window.search.SearchWindow_Objects" value="Objekten"/>
         <entry key="view.window.about.AboutWindow_Title" value="About Edirom Online"/>
         <entry key="view.window.about.AboutWindow_License" value="Lizenz"/>
@@ -167,14 +167,14 @@
         <entry key="view.window.source.SourceView_pageNaviation" value="Seiten-Navigation"/>
         <entry key="view.window.source.SourceView_measureBasedCombo" value="Nummern Kombobox"/>
         <entry key="view.window.source.SourceView_measureBasedRange" value="Bereich der Takte"/>
-        
+
         <entry key="view.window.xmlView_decreaseFontSize.label" value="A-"/>
         <entry key="view.window.xmlView_decreaseFontSize.title" value="Schriftgröße verkleinern"/>
         <entry key="view.window.xmlView_increaseFontSize.label" value="A+"/>
         <entry key="view.window.xmlView_increaseFontSize.title" value="Schriftgröße vergrößern"/>
         <entry key="view.window.xmlView_showLineNumbers.label" value="Zeile #"/>
         <entry key="view.window.xmlView_showLineNumbers.title" value="Zeilennummern anzeigen"/>
-        
+
         <entry key="view.window.pref_generalSettings" value="Generell"/>
         <entry key="view.window.pref_programSettings" value="Programmeinstellungen"/>
         <entry key="view.window.pref_concNavSettings" value="Einstellungen für Konkordanznavigator"/>
@@ -207,27 +207,27 @@
         <entry key="perfMedium.perfRes.alto" value="Alt"/>
         <entry key="perfMedium.perfRes.tenor" value="Tenor"/>
         <entry key="perfMedium.perfRes.bass" value="Bass"/>
-        
+
         <entry key="perfMedium.perfRes.violin" value="Violine"/>
         <entry key="perfMedium.perfRes.viola" value="Viola"/>
         <entry key="perfMedium.perfRes.violoncello" value="Violoncello"/>
         <entry key="perfMedium.perfRes.doubleBass" value="Kontrabass"/>
         <entry key="perfMedium.perfRes.bassInstrumental" value="Bass (instrumental)"/>
-        
+
         <entry key="perfMedium.perfRes.flute" value="Flöte"/>
         <entry key="perfMedium.perfRes.oboe" value="Oboe"/>
         <entry key="perfMedium.perfRes.clarinet" value="Klarinette"/>
         <entry key="perfMedium.perfRes.hornEnglish" value="Englischhorn"/>
         <entry key="perfMedium.perfRes.bassoon" value="Fagott"/>
-        
+
         <entry key="perfMedium.perfRes.hornFrench" value="Horn"/>
         <entry key="perfMedium.perfRes.trumpet" value="Trompete"/>
         <entry key="perfMedium.perfRes.trombone" value="Posaune"/>
         <entry key="perfMedium.perfRes.tuba" value="Tuba"/>
-        
+
         <entry key="perfMedium.perfRes.timpani" value="Pauken"/>
         <entry key="perfMedium.perfRes.bells" value="Glocken"/>
-        
+
         <entry key="perfMedium.perfRes.harp" value="Harfe"/>
         <entry key="perfMedium.perfRes.piano" value="Klavier"/>
         <entry key="perfMedium.perfRes.organ" value="Orgel"/>

--- a/data/locale/edirom-lang-de.xml
+++ b/data/locale/edirom-lang-de.xml
@@ -33,7 +33,7 @@
 
         <entry key="controller.desktop.TaskBar_confirmReload" value="Die Anwendung muss neu gestartet werden, damit die Spracheinstellung vollständig umgesetzt wird."/>
 
-        <entry key="controller.window.Window_annotationView" value="Anmerkung"/>
+        <entry key="controller.window.Window_annotationView" value="Anmerkungen"/>
         <entry key="controller.window.Window_headerView" value="Metadaten"/>
         <entry key="controller.window.Window_renderingView" value="Rendering"/>
         <entry key="controller.window.Window_searchView" value="Suche"/>
@@ -83,8 +83,8 @@
         <entry key="view.window.AnnotationView_Participants" value="Subjekte"/>
         <entry key="view.window.AnnotationView_Source" value="Quelle"/>
         <entry key="view.window.AnnotationView_Sources" value="Quellen"/>
-        <entry key="view.window.AnnotationView_Siglum" value="Siglum"/>
-        <entry key="view.window.AnnotationView_Sigla" value="Siglen"/>
+        <entry key="view.window.AnnotationView_Siglum" value="Quellensigle"/>
+        <entry key="view.window.AnnotationView_Sigla" value="Quellensiglen"/>
         <entry key="view.window.AnnotationView_AnnotationID" value="Annot.-ID"/>
         <entry key="view.window.AnnotationView_List" value="Liste"/>
         <entry key="view.window.AnnotationView_Display" value="Darstellung"/>

--- a/data/locale/edirom-lang-en.xml
+++ b/data/locale/edirom-lang-en.xml
@@ -74,6 +74,7 @@
         <entry key="view.desktop.TaskBar_Sort_horizontal" value="Sort windows horizontally"/>
         <entry key="view.desktop.TopBar_homeBtnLabel" value="Edirom Online"/>
         <entry key="view.window.AnnotationView_Title" value="Annotation"/>
+        
         <entry key="view.window.AnnotationView_No" value="No."/>
         <entry key="view.window.AnnotationView_TitleLabel" value="Title"/>
         <entry key="view.window.AnnotationView_Categories" value="Categories"/>
@@ -90,11 +91,11 @@
         <entry key="view.window.AnnotationView_Grid" value="Grid view"/>
         <entry key="view.window.AnnotationView_Single" value="Single view"/>
         <entry key="view.window.AnnotationView_ListView" value="List view"/>
-        
         <entry key="view.window.AnnotationView_PreviousAnnotation" value="Previous annotation"/>
         <entry key="view.window.AnnotationView_NextAnnotation" value="Next annotation"/>
         <entry key="view.window.AnnotationView_OpenAll" value="Open all sources"/>
         <entry key="view.window.AnnotationView_CloseAll" value="Close all sources"/>
+        
         <entry key="view.window.HelpWindow_Title" value="Help"/>
         <entry key="view.window.TopBar_View" value="View"/>
         

--- a/data/locale/edirom-lang-en.xml
+++ b/data/locale/edirom-lang-en.xml
@@ -73,8 +73,8 @@
         <entry key="view.desktop.TaskBar_Sort_vertical" value="Sort windows vertically"/>
         <entry key="view.desktop.TaskBar_Sort_horizontal" value="Sort windows horizontally"/>
         <entry key="view.desktop.TopBar_homeBtnLabel" value="Edirom Online"/>
-        <entry key="view.window.AnnotationView_Title" value="Annotation"/>
         
+        <entry key="view.window.AnnotationView_Title" value="Annotations"/>
         <entry key="view.window.AnnotationView_No" value="No."/>
         <entry key="view.window.AnnotationView_TitleLabel" value="Title"/>
         <entry key="view.window.AnnotationView_Categories" value="Categories"/>

--- a/data/locale/edirom-lang-en.xml
+++ b/data/locale/edirom-lang-en.xml
@@ -78,8 +78,8 @@
         <entry key="view.window.AnnotationView_No" value="No."/>
         <entry key="view.window.AnnotationView_TitleLabel" value="Title"/>
         <entry key="view.window.AnnotationView_Categories" value="Categories"/>
-        <entry key="view.window.AnnotationView_Category" value="Category"/>
-        <entry key="view.window.AnnotationView_Priority" value="Priority"/>
+        <entry key="view.window.AnnotationView_ediromCategory" value="Category"/>
+        <entry key="view.window.AnnotationView_ediromPriority" value="Priority"/>
         <entry key="view.window.AnnotationView_Participants" value="Participants"/>
         <entry key="view.window.AnnotationView_Source" value="Source"/>
         <entry key="view.window.AnnotationView_Sources" value="Sources"/>

--- a/data/locale/edirom-lang-en.xml
+++ b/data/locale/edirom-lang-en.xml
@@ -77,9 +77,9 @@
         <entry key="view.window.AnnotationView_Title" value="Annotations"/>
         <entry key="view.window.AnnotationView_No" value="No."/>
         <entry key="view.window.AnnotationView_TitleLabel" value="Title"/>
-        <entry key="view.window.AnnotationView_Categories" value="Categories"/>
-        <entry key="view.window.AnnotationView_ediromCategory" value="Category"/>
-        <entry key="view.window.AnnotationView_ediromPriority" value="Priority"/>
+        <entry key="ediromCategory_multiple" value="Categories"/>
+        <entry key="ediromCategory" value="Category"/>
+        <entry key="ediromPriority" value="Priority"/>
         <entry key="view.window.AnnotationView_Participants" value="Participants"/>
         <entry key="view.window.AnnotationView_Source" value="Source"/>
         <entry key="view.window.AnnotationView_Sources" value="Sources"/>

--- a/data/prefs/edirom-prefs.xml
+++ b/data/prefs/edirom-prefs.xml
@@ -24,6 +24,11 @@
     <entries>
         <entry key="application_language" value="de"/>
         <entry key="annotation_layout" value="EdiromOnline.view.window.annotationLayouts.AnnotationLayout1"/>
+        <!-- annotation_hide_legacy_fields: hides legacy annotation fields (categories, priority) in the annotation grid
+             on initial render. Defaults to true since editions using ediromCategory/ediromPriority taxonomies would
+             otherwise show duplicate columns. Set to "false" in edition prefs to show legacy fields.
+             See app/controller/window/AnnotationView.js -->
+        <entry key="annotation_hide_legacy_fields" value="false"/>
         <entry key="image_prefix" value="../../../digilib/Scaler/"/>
         <entry key="image_server" value="digilib"/>
         <entry key="edition_path" value="/db/apps/contents"/>

--- a/data/xql/getAnnotation.xql
+++ b/data/xql/getAnnotation.xql
@@ -323,15 +323,15 @@ let $participants := annotation:getParticipants($annot)
 
 let $priority := local:getPriority($annot)
 
-let $priorityLabel := eutil:getLanguageString('view.window.AnnotationView_Priority', (), $lang)
+let $priorityLabel := eutil:getLanguageString('view.window.AnnotationView_ediromPriority', (), $lang)
 
 let $categories := local:getCategories($annot)
 
 let $categoriesLabel :=
     if (count($categories) gt 1) then
-        eutil:getLanguageString('view.window.AnnotationView_Categories', (), $lang)
+        eutil:getLanguageString('view.window.AnnotationView_ediromCategories', (), $lang)
     else
-        eutil:getLanguageString('view.window.AnnotationView_Category', (), $lang)
+        eutil:getLanguageString('view.window.AnnotationView_ediromCategory', (), $lang)
 
 let $sources := doc:getDocumentsLabelsAsArray($participants, $edition)
 

--- a/data/xql/getAnnotationInfos.xql
+++ b/data/xql/getAnnotationInfos.xql
@@ -90,7 +90,7 @@ let $annots := $editionCollection//mei:annot[matches(@plist, $uri)] | $mei//mei:
 let $categories :=
     for $category in local:getDistinctCategories($annots)
     let $categoryElement := ($editionCollection/id($category)[mei:label or mei:name])[1]
-    let $name := annotation:get-category-label-localized($categoryElement, eutil:getLanguage($edition))
+    let $name := annotation:get-category-label-localized($categoryElement)
     order by $name
     return
         map {

--- a/data/xql/getAnnotationInfos.xql
+++ b/data/xql/getAnnotationInfos.xql
@@ -40,17 +40,17 @@ declare variable $edition := request:get-parameter('edition', '');
  : @return a sequence of strings
  :)
 declare function local:getDistinctCategories($annots as element()*) as xs:string* {
-    
+
     (: older Edirom Online models (pre MEI 4) :)
     let $oldCats := distinct-values($annots/mei:ptr[@type = "categories"]/replace(@target, '#', ''))
-    
+
     (: MEI 4 and above Edirom Online model using @class and mei:taxonomy :)
     let $newCats :=
         distinct-values(
             for $annot in $annots
             return
                 tokenize(replace(normalize-space($annot/@class), '#', ''), ' '))[contains(., 'annotation.category')]
-    
+
     return
         distinct-values(($oldCats, $newCats)[string-length() gt 0])
 };
@@ -63,18 +63,18 @@ declare function local:getDistinctCategories($annots as element()*) as xs:string
  : @return a sequence of strings
  :)
 declare function local:getDistinctPriorities($annots as element()*) as xs:string* {
-    
+
     distinct-values(
         for $annot in $annots
-        
+
         (: older Edirom Online models (pre MEI 4) :)
         let $oldLink := $annot/mei:ptr[@type = "priority"]/replace(@target, '#', '')
-        
+
         (: MEI 4 and above Edirom Online model using @class and mei:taxonomy :)
         let $classes := tokenize(replace(normalize-space($annot/@class), '#', ''), ' ')
-        
+
         let $newLink := $classes[starts-with(., 'ediromAnnotPrio')]
-        
+
         return
             distinct-values(($oldLink, $newLink))[string-length(.) gt 0]
     )
@@ -90,7 +90,7 @@ let $annots := $editionCollection//mei:annot[matches(@plist, $uri)] | $mei//mei:
 let $categories :=
     for $category in local:getDistinctCategories($annots)
     let $categoryElement := ($editionCollection/id($category)[mei:label or mei:name])[1]
-    let $name := eutil:getLocalizedName($categoryElement, edition:getLanguage($edition))
+    let $name := annotation:get-category-label-localized($categoryElement, eutil:getLanguage($edition))
     order by $name
     return
         map {

--- a/data/xql/getAnnotationInfos.xql
+++ b/data/xql/getAnnotationInfos.xql
@@ -8,7 +8,7 @@ xquery version "3.1";
 
 import module namespace annotation = "http://www.edirom.de/xquery/annotation" at "../xqm/annotation.xqm";
 import module namespace edition = "http://www.edirom.de/xquery/edition" at "../xqm/edition.xqm";
-import module namespace eutil = "http://www.edirom.de/xquery/eutil" at "../xqm/eutil.xqm";
+import module namespace taxonomy = "http://www.edirom.de/xquery/taxonomy" at "../xqm/taxonomy.xqm";
 
 
 (: NAMESPACE DECLARATIONS ================================================== :)
@@ -28,57 +28,7 @@ declare option output:media-type "application/json";
 
 declare variable $uri := request:get-parameter('uri', '');
 declare variable $edition := request:get-parameter('edition', '');
-
-
-(: FUNCTION DECLARATIONS =================================================== :)
-
-(:~
- : Returns distinct list of catagories used be the submitted annotations
- :
- : @param $annots a sequence of annotation elements (usually mei:annot)
- :
- : @return a sequence of strings
- :)
-declare function local:getDistinctCategories($annots as element()*) as xs:string* {
-
-    (: older Edirom Online models (pre MEI 4) :)
-    let $oldCats := distinct-values($annots/mei:ptr[@type = "categories"]/replace(@target, '#', ''))
-
-    (: MEI 4 and above Edirom Online model using @class and mei:taxonomy :)
-    let $newCats :=
-        distinct-values(
-            for $annot in $annots
-            return
-                tokenize(replace(normalize-space($annot/@class), '#', ''), ' '))[contains(., 'annotation.category')]
-
-    return
-        distinct-values(($oldCats, $newCats)[string-length() gt 0])
-};
-
-(:~
- : Returns distinct list of annotation priorities used by the submitted annotations
- :
- : @param $annots a sequence of annotation elements (usually mei:annot)
- :
- : @return a sequence of strings
- :)
-declare function local:getDistinctPriorities($annots as element()*) as xs:string* {
-
-    distinct-values(
-        for $annot in $annots
-
-        (: older Edirom Online models (pre MEI 4) :)
-        let $oldLink := $annot/mei:ptr[@type = "priority"]/replace(@target, '#', '')
-
-        (: MEI 4 and above Edirom Online model using @class and mei:taxonomy :)
-        let $classes := tokenize(replace(normalize-space($annot/@class), '#', ''), ' ')
-
-        let $newLink := $classes[starts-with(., 'ediromAnnotPrio')]
-
-        return
-            distinct-values(($oldLink, $newLink))[string-length(.) gt 0]
-    )
-};
+declare variable $lang := request:get-parameter('lang', '');
 
 
 (: QUERY BODY ============================================================== :)
@@ -87,33 +37,38 @@ let $mei := eutil:getDoc($uri)
 let $editionCollection := edition:collection($edition)
 let $annots := $editionCollection//mei:annot[matches(@plist, $uri)] | $mei//mei:annot
 
-let $categories :=
-    for $category in local:getDistinctCategories($annots)
-    let $categoryElement := ($editionCollection/id($category)[mei:label or mei:name])[1]
-    let $name := annotation:get-category-label-localized($categoryElement)
-    order by $name
+let $allClassElements :=
+    for $annot in $annots
+    let $doc := $annot/root()
+    for $classIDREF in annotation:get-class-idrefs-as-sequence($annot)
+    return $doc/id($classIDREF)
+
+let $taxonomiesArray := array {
+    for $elem in $allClassElements[ancestor::mei:taxonomy]
+    let $taxonomyId := taxonomy:get-parent-taxonomy-identifying-string($elem)
+    group by $taxonomyId
+    let $taxonomyElem := $elem[1]/ancestor-or-self::mei:taxonomy[1]
+    let $taxonomyLabels := taxonomy:get-labels($taxonomyElem)
+    let $taxonomyLabel := ($taxonomyLabels($lang)[. != ''], $taxonomyLabels('und')[. != ''], $taxonomyId)[1]
     return
         map {
-            'id': $category,
-            'name': $name
+            'id': $taxonomyId,
+            'label': $taxonomyLabel,
+            'items': array {
+                for $id in distinct-values($elem/@xml:id)
+                let $e := ($elem[@xml:id = $id])[1]
+                order by taxonomy:get-label-localized-as-string($e)
+                return
+                    map {
+                        'id': xs:string($id),
+                        'name': taxonomy:get-label-localized-as-string($e)
+                    }
+            }
         }
-
-let $prios :=
-    for $priority in local:getDistinctPriorities($annots)
-    let $name := annotation:getPriorityLabel(($editionCollection/id($priority)[mei:label or mei:name])[1])
-    order by $name
-    return
-        map {
-            'id': $priority,
-            'name': $name
-        }
-
-let $map :=
-   map {
-       'categories': array {$categories},
-       'priorities': array {$prios},
-       'count': count($annots)
-   }
+}
 
 return
-    $map
+    map {
+        'count': count($annots),
+        'taxonomies': $taxonomiesArray
+    }

--- a/data/xql/getAnnotationInfos.xql
+++ b/data/xql/getAnnotationInfos.xql
@@ -8,6 +8,7 @@ xquery version "3.1";
 
 import module namespace annotation = "http://www.edirom.de/xquery/annotation" at "../xqm/annotation.xqm";
 import module namespace edition = "http://www.edirom.de/xquery/edition" at "../xqm/edition.xqm";
+import module namespace eutil = "http://www.edirom.de/xquery/eutil" at "../xqm/eutil.xqm";
 import module namespace taxonomy = "http://www.edirom.de/xquery/taxonomy" at "../xqm/taxonomy.xqm";
 
 
@@ -31,16 +32,105 @@ declare variable $edition := request:get-parameter('edition', '');
 declare variable $lang := request:get-parameter('lang', '');
 
 
+(: FUNCTION DECLARATIONS =================================================== :)
+
+(:~
+ : Returns distinct list of catagories used be the submitted annotations
+ :
+ : @param $annots a sequence of annotation elements (usually mei:annot)
+ :
+ : @return a sequence of strings
+ :
+ : @deprecated This function will be deprecated with Edirom-Online-API 2.0.0
+ :)
+declare function local:getDistinctCategories($annots as element()*) as xs:string* {
+
+    (: older Edirom Online models (pre MEI 4) :)
+    let $oldCats := distinct-values($annots/mei:ptr[@type = "categories"]/replace(@target, '#', ''))
+
+    (: MEI 4 and above Edirom Online model using @class and mei:taxonomy :)
+    let $newCats :=
+        distinct-values(
+            for $annot in $annots
+            return
+                tokenize(replace(normalize-space($annot/@class), '#', ''), ' '))[contains(., 'annotation.category')]
+
+    return
+        distinct-values(($oldCats, $newCats)[string-length() gt 0])
+};
+
+(:~
+ : Returns distinct list of annotation priorities used by the submitted annotations
+ :
+ : @param $annots a sequence of annotation elements (usually mei:annot)
+ :
+ : @return a sequence of strings
+ :
+ : @deprecated This function will be deprecated with Edirom-Online-API 2.0.0
+ :)
+declare function local:getDistinctPriorities($annots as element()*) as xs:string* {
+
+    distinct-values(
+        for $annot in $annots
+
+        (: older Edirom Online models (pre MEI 4) :)
+        let $oldLink := $annot/mei:ptr[@type = "priority"]/replace(@target, '#', '')
+
+        (: MEI 4 and above Edirom Online model using @class and mei:taxonomy :)
+        let $classes := tokenize(replace(normalize-space($annot/@class), '#', ''), ' ')
+
+        let $newLink := $classes[starts-with(., 'ediromAnnotPrio')]
+
+        return
+            distinct-values(($oldLink, $newLink))[string-length(.) gt 0]
+    )
+};
+
+
 (: QUERY BODY ============================================================== :)
 
 let $mei := eutil:getDoc($uri)
 let $editionCollection := edition:collection($edition)
-let $annots := $editionCollection//mei:annot[@type = 'editorialComment'][matches(@plist, $uri)] | $mei//mei:annot[@type = 'editorialComment']
+let $annots :=
+    $editionCollection//mei:annot[@type = 'editorialComment'][matches(@plist, $uri)]
+    | $mei//mei:annot[@type = 'editorialComment']
 
-let $taxonomiesArray := annotation:get-referenced-categories-as-taxonomy-array($annots, ($mei, $editionCollection), $lang)
+(: NOTE: the deprecated categories/priorities fields below still resolve their label elements
+   collection-wide via id() over the whole edition, rather than per-reference via
+   eutil:get-referenced-element like every other path. This is left as-is for now because the
+   fields are slated for removal with Edirom-Online-API 2.0.0 and are superseded by the
+   'taxonomies' array; when migrating or removing them, route resolution through the shared
+   resolver for consistency. :)
+let $categories :=
+    for $category in local:getDistinctCategories($annots)
+    let $categoryElement := ($editionCollection/id($category)[mei:label or mei:name])[1]
+    let $name := eutil:getLocalizedName($categoryElement, edition:getLanguage($edition))
+    order by $name
+    return
+        map {
+            'id': $category,
+            'name': $name
+        }
+
+let $prios :=
+    for $priority in local:getDistinctPriorities($annots)
+    let $name := annotation:getPriorityLabel(($editionCollection/id($priority)[mei:label or mei:name])[1])
+    order by $name
+    return
+        map {
+            'id': $priority,
+            'name': $name
+        }
+
+let $taxonomiesArray :=
+    annotation:get-referenced-categories-as-taxonomy-array($annots, ($mei, $editionCollection), $lang)
 
 return
     map {
+        (: TODO deprecate categories field with Edirom-Online-API 2.0.0 :)
+        'categories': $categories,
+        (: TODO deprecate priorities field with Edirom-Online-API 2.0.0 :)
+        'priorities': $prios,
         'count': count($annots),
         'taxonomies': $taxonomiesArray
     }

--- a/data/xql/getAnnotationInfos.xql
+++ b/data/xql/getAnnotationInfos.xql
@@ -37,14 +37,10 @@ let $mei := eutil:getDoc($uri)
 let $editionCollection := edition:collection($edition)
 let $annots := $editionCollection//mei:annot[matches(@plist, $uri)] | $mei//mei:annot
 
-let $allClassElements :=
-    for $annot in $annots
-    let $doc := $annot/root()
-    for $classIDREF in annotation:get-class-idrefs-as-sequence($annot)
-    return $doc/id($classIDREF)
+let $categoryElements := annotation:get-referenced-category-elements($annots, ($mei, $editionCollection))
 
 let $taxonomiesArray := array {
-    for $elem in $allClassElements[ancestor::mei:taxonomy]
+    for $elem in $categoryElements
     let $taxonomyId := taxonomy:get-parent-taxonomy-identifying-string($elem)
     group by $taxonomyId
     let $taxonomyElem := $elem[1]/ancestor-or-self::mei:taxonomy[1]

--- a/data/xql/getAnnotationInfos.xql
+++ b/data/xql/getAnnotationInfos.xql
@@ -35,33 +35,9 @@ declare variable $lang := request:get-parameter('lang', '');
 
 let $mei := eutil:getDoc($uri)
 let $editionCollection := edition:collection($edition)
-
-let $categoryElements := annotation:get-referenced-category-elements($annots, ($mei, $editionCollection))
 let $annots := $editionCollection//mei:annot[@type = 'editorialComment'][matches(@plist, $uri)] | $mei//mei:annot[@type = 'editorialComment']
 
-let $taxonomiesArray := array {
-    for $elem in $categoryElements
-    let $taxonomyId := taxonomy:get-parent-taxonomy-identifying-string($elem)
-    group by $taxonomyId
-    let $taxonomyElem := $elem[1]/ancestor-or-self::mei:taxonomy[1]
-    let $taxonomyLabels := taxonomy:get-labels($taxonomyElem)
-    let $taxonomyLabel := ($taxonomyLabels($lang)[. != ''], $taxonomyLabels('und')[. != ''], $taxonomyId)[1]
-    return
-        map {
-            'id': $taxonomyId,
-            'label': $taxonomyLabel,
-            'items': array {
-                for $id in distinct-values($elem/@xml:id)
-                let $e := ($elem[@xml:id = $id])[1]
-                order by taxonomy:get-label-localized-as-string($e)
-                return
-                    map {
-                        'id': xs:string($id),
-                        'name': taxonomy:get-label-localized-as-string($e)
-                    }
-            }
-        }
-}
+let $taxonomiesArray := annotation:get-referenced-categories-as-taxonomy-array($annots, ($mei, $editionCollection), $lang)
 
 return
     map {

--- a/data/xql/getAnnotationInfos.xql
+++ b/data/xql/getAnnotationInfos.xql
@@ -35,9 +35,9 @@ declare variable $lang := request:get-parameter('lang', '');
 
 let $mei := eutil:getDoc($uri)
 let $editionCollection := edition:collection($edition)
-let $annots := $editionCollection//mei:annot[matches(@plist, $uri)] | $mei//mei:annot
 
 let $categoryElements := annotation:get-referenced-category-elements($annots, ($mei, $editionCollection))
+let $annots := $editionCollection//mei:annot[@type = 'editorialComment'][matches(@plist, $uri)] | $mei//mei:annot[@type = 'editorialComment']
 
 let $taxonomiesArray := array {
     for $elem in $categoryElements

--- a/data/xql/getAnnotationInfos.xql
+++ b/data/xql/getAnnotationInfos.xql
@@ -92,7 +92,10 @@ declare function local:getDistinctPriorities($annots as element()*) as xs:string
 let $mei := eutil:getDoc($uri)
 let $editionCollection := edition:collection($edition)
 let $annots :=
-    $editionCollection//mei:annot[@type = 'editorialComment'][matches(@plist, $uri)]
+    $editionCollection//mei:annot[@type = 'editorialComment'][
+        some $p in tokenize(normalize-space(@plist), '\s+')
+        satisfies (if (contains($p, '#')) then substring-before($p, '#') else $p) = $uri
+    ]
     | $mei//mei:annot[@type = 'editorialComment']
 
 (: NOTE: the deprecated categories/priorities fields below still resolve their label elements

--- a/data/xql/getAnnotationMeta.xql
+++ b/data/xql/getAnnotationMeta.xql
@@ -11,6 +11,8 @@ xquery version "3.1";
     @author <a href="mailto:bohl@edirom.de">Benjamin W. Bohl</a>
 :)
 
+(: TODO move a way from returning HTML for Edirom-API 2.0 :)
+
 (: IMPORTS ================================================================= :)
 
 import module namespace annotation = "http://www.edirom.de/xquery/annotation" at "../xqm/annotation.xqm";

--- a/data/xql/getAnnotationMeta.xql
+++ b/data/xql/getAnnotationMeta.xql
@@ -50,7 +50,7 @@ let $priorityLabel := switch ($priority)
     default return
         eutil:getLanguageString('view.window.AnnotationView_Priority', ())
 
-let $categories := annotation:getCategoriesAsArray($annot)
+let $categories := annotation:get-category-labels-as-sequence($annot)
 let $categoriesLabel := switch (count($categories))
     case 0
         return

--- a/data/xql/getAnnotationMeta.xql
+++ b/data/xql/getAnnotationMeta.xql
@@ -39,26 +39,7 @@ let $annot := $doc/id($internalId)
 
 let $participants := annotation:getParticipants($annot)
 
-let $categoryElements := annotation:get-referenced-category-elements($annot, $doc)
-
-let $taxonomyGroups :=
-    for $elem in $categoryElements
-    let $taxonomyId := taxonomy:get-parent-taxonomy-identifying-string($elem)
-    group by $taxonomyId
-    let $taxonomyElem := $elem[1]/ancestor-or-self::mei:taxonomy[1]
-    let $taxonomyLabels := taxonomy:get-labels($taxonomyElem)
-    let $taxonomyLabel := ($taxonomyLabels($lang)[. != ''], $taxonomyLabels('und')[. != ''], $taxonomyId)[1]
-    let $displayLabel := if ($taxonomyLabel != $taxonomyId) then $taxonomyLabel else eutil:getLanguageString($taxonomyId, ())
-    return
-        map {
-            'id': $taxonomyId,
-            'label': $displayLabel,
-            'values': string-join(
-                for $e in $elem
-                return taxonomy:get-label-localized-as-string($e),
-                ', '
-            )
-        }
+let $taxonomiesArray := annotation:get-referenced-categories-as-taxonomy-array($annot, $doc, $lang)
 
 let $sigla := source:getSiglaAsArray($participants)
 let $siglaLabel := switch (count($sigla))
@@ -76,12 +57,12 @@ return
     <div class="annotView">
         <div class="metaBox">
             {
-                for $t in $taxonomyGroups
+                for $t in $taxonomiesArray?*
                 (: TODO process single vs. _multiple for keys :)
                 return
                     <div class="property taxonomy-{$t('id')}">
                         <div class="key">{$t('label')}</div>
-                        <div class="value">{$t('values')}</div>
+                        <div class="value">{string-join($t('items')?*?name, ', ')}</div>
                     </div>
             }
             <div class="property sourceSiglums">

--- a/data/xql/getAnnotationMeta.xql
+++ b/data/xql/getAnnotationMeta.xql
@@ -112,7 +112,9 @@ return
                                     (eutil:getLanguageString(edition:getLanguageFileURI($edition, $lang), $t('id'), (), $lang), $t('id'))[1]
                                 default return
                                     (: for more than one item try to fetch plural label, fallback to singular, then to id :)
-                                    (eutil:getLanguageString(edition:getLanguageFileURI($edition, $lang), $t('id') || '_multiple', (), $lang), eutil:getLanguageString(edition:getLanguageFileURI($edition, $lang)), $t('id'))[1]
+                                    (eutil:getLanguageString(edition:getLanguageFileURI($edition, $lang), $t('id') || '_multiple', (), $lang),
+                                     eutil:getLanguageString(edition:getLanguageFileURI($edition, $lang), $t('id'))
+                                     )[1]
                         }</div>
                         <div class="value">{string-join($t('items')?*?name, ', ')}</div>
                     </div>

--- a/data/xql/getAnnotationMeta.xql
+++ b/data/xql/getAnnotationMeta.xql
@@ -105,9 +105,14 @@ return
                         <div class="key">{
                             (: mirror the frontend: a real @label is used as-is, otherwise the
                                identifier is looked up in the locale files (id as last resort) :)
-                            if ($t('label') != $t('id'))
-                            then $t('label')
-                            else (eutil:getLanguageString(edition:getLanguageFileURI($edition, $lang), $t('id'), (), $lang), $t('id'))[1]
+                            if ($t('label') != $t('id')) then
+                                $t('label')
+                            else switch(array:size($t('items')))
+                                case 1 return
+                                    (eutil:getLanguageString(edition:getLanguageFileURI($edition, $lang), $t('id'), (), $lang), $t('id'))[1]
+                                default return
+                                    (: for more than one item try to fetch plural label, fallback to singular, then to id :)
+                                    (eutil:getLanguageString(edition:getLanguageFileURI($edition, $lang), $t('id') || '_multiple', (), $lang), eutil:getLanguageString(edition:getLanguageFileURI($edition, $lang)), $t('id'))[1]
                         }</div>
                         <div class="value">{string-join($t('items')?*?name, ', ')}</div>
                     </div>

--- a/data/xql/getAnnotationMeta.xql
+++ b/data/xql/getAnnotationMeta.xql
@@ -75,7 +75,7 @@ let $siglaLabel := switch (count($sigla))
             ()
     case 1
         return
-            eutil:getLanguageString('view.window.AnnotationView_Source', ()) (:TODO check for lang key:)
+            eutil:getLanguageString('view.window.AnnotationView_Source', ())
     default return
         eutil:getLanguageString('view.window.AnnotationView_Sources', ())
 let $annotIDlabel := eutil:getLanguageString('view.window.AnnotationView_AnnotationID', ())

--- a/data/xql/getAnnotationMeta.xql
+++ b/data/xql/getAnnotationMeta.xql
@@ -16,16 +16,13 @@ import module namespace annotation = "http://www.edirom.de/xquery/annotation" at
 import module namespace doc = "http://www.edirom.de/xquery/document" at "../xqm/document.xqm";
 import module namespace eutil = "http://www.edirom.de/xquery/eutil" at "../xqm/eutil.xqm";
 import module namespace source = "http://www.edirom.de/xquery/source" at "../xqm/source.xqm";
+import module namespace taxonomy = "http://www.edirom.de/xquery/taxonomy" at "../xqm/taxonomy.xqm";
 
 (: NAMESPACE DECLARATIONS ================================================== :)
 
-declare namespace edirom_image = "http://www.edirom.de/ns/image";
-declare namespace exist = "http://exist.sourceforge.net/NS/exist";
 declare namespace mei = "http://www.music-encoding.org/ns/mei";
-declare namespace request = "http://exist-db.org/xquery/request";
-
-declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
 declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
+declare namespace request = "http://exist-db.org/xquery/request";
 
 (: OPTION DECLARATIONS ===================================================== :)
 
@@ -42,81 +39,60 @@ let $annot := $doc/id($internalId)
 
 let $participants := annotation:getParticipants($annot)
 
-let $priority := annotation:getPriorityLabel($annot)
-let $priorityLabel := switch ($priority)
-    case ""
-        return
-            ()
-    default return
-        eutil:getLanguageString('view.window.AnnotationView_Priority', ())
+let $classElements :=
+    for $classIDREF in annotation:get-class-idrefs-as-sequence($annot)
+    return $doc/id($classIDREF)
 
-let $categories := annotation:get-category-labels-as-sequence($annot)
-let $categoriesLabel := switch (count($categories))
-    case 0
-        return
-            ()
-    case 1
-        return
-            eutil:getLanguageString('view.window.AnnotationView_Category', ())
-    default return
-        eutil:getLanguageString('view.window.AnnotationView_Categories', ())
-
-let $sources := doc:getDocumentsLabelsAsArray($participants, $edition)
-let $sourcesLabel := if (count($sources) gt 1)
-then
-    (eutil:getLanguageString('view.window.AnnotationView_Sources', ()))
-else
-    (eutil:getLanguageString('view.window.AnnotationView_Source', ()))
+let $taxonomyGroups :=
+    for $elem in $classElements[ancestor::mei:taxonomy]
+    let $taxonomyId := taxonomy:get-parent-taxonomy-identifying-string($elem)
+    group by $taxonomyId
+    let $taxonomyElem := $elem[1]/ancestor-or-self::mei:taxonomy[1]
+    let $taxonomyLabels := taxonomy:get-labels($taxonomyElem)
+    let $taxonomyLabel := ($taxonomyLabels($lang)[. != ''], $taxonomyLabels('und')[. != ''], $taxonomyId)[1]
+    let $displayLabel := if ($taxonomyLabel != $taxonomyId) then $taxonomyLabel else eutil:getLanguageString($taxonomyId, ())
+    return
+        map {
+            'id': $taxonomyId,
+            'label': $displayLabel,
+            'values': string-join(
+                for $e in $elem
+                return taxonomy:get-label-localized-as-string($e),
+                ', '
+            )
+        }
 
 let $sigla := source:getSiglaAsArray($participants)
 let $siglaLabel := switch (count($sigla))
-    case 0
-        return
-            ()
-    case 1
-        return
-            eutil:getLanguageString('view.window.AnnotationView_Source', ())
+    case 0 return
+        ()
+    case 1 return
+        eutil:getLanguageString('view.window.AnnotationView_Source', ())
     default return
         eutil:getLanguageString('view.window.AnnotationView_Sources', ())
+
 let $annotIDlabel := eutil:getLanguageString('view.window.AnnotationView_AnnotationID', ())
 
 return
-    
-    <div
-        class="annotView">
-        <div
-            class="metaBox">
-            <div
-                class="property priority">
-                <div
-                    class="key">{$priorityLabel}</div>
-                <div
-                    class="value">{$priority}</div>
+
+    <div class="annotView">
+        <div class="metaBox">
+            {
+                for $t in $taxonomyGroups
+                (: TODO process single vs. _multiple for keys :)
+                return
+                    <div class="property taxonomy-{$t('id')}">
+                        <div class="key">{$t('label')}</div>
+                        <div class="value">{$t('values')}</div>
+                    </div>
+            }
+            <div class="property sourceSiglums">
+                <div class="key">{$siglaLabel}</div>
+                <div class="value">{string-join($sigla, ', ')}</div>
             </div>
-            <div
-                class="property categories">
-                <div
-                    class="key">{$categoriesLabel}</div>
-                <div
-                    class="value">{string-join($categories, ', ')}</div>
-            </div>
-            <!--<div class="property sourceLabel">
-                <div class="key">{$sourcesLabel}</div>
-                <div class="value">{string-join($sources, ', ')}</div>
-            </div>-->
-            <div
-                class="property sourceSiglums">
-                <div
-                    class="key">{$siglaLabel}</div>
-                <div
-                    class="value">{string-join($sigla, ', ')}</div>
-            </div>
-            <div
-                class="property annotID">
-                <div
-                    class="key">{$annotIDlabel}</div>
-                <div
-                    class="value">{$internalId}</div>
+            <div class="property annotID">
+                <div class="key">{$annotIDlabel}</div>
+                <div class="value">{$internalId}</div>
             </div>
         </div>
     </div>

--- a/data/xql/getAnnotationMeta.xql
+++ b/data/xql/getAnnotationMeta.xql
@@ -102,7 +102,13 @@ return
                 (: TODO process single vs. _multiple for keys :)
                 return
                     <div class="property taxonomy-{$t('id')}">
-                        <div class="key">{(eutil:getLanguageString(edition:getLanguageFileURI($edition, $lang), $t('label'), (), $lang), $t('label'))[1]}</div>
+                        <div class="key">{
+                            (: mirror the frontend: a real @label is used as-is, otherwise the
+                               identifier is looked up in the locale files (id as last resort) :)
+                            if ($t('label') != $t('id'))
+                            then $t('label')
+                            else (eutil:getLanguageString(edition:getLanguageFileURI($edition, $lang), $t('id'), (), $lang), $t('id'))[1]
+                        }</div>
                         <div class="value">{string-join($t('items')?*?name, ', ')}</div>
                     </div>
             }

--- a/data/xql/getAnnotationMeta.xql
+++ b/data/xql/getAnnotationMeta.xql
@@ -100,7 +100,7 @@ return
                 (: TODO process single vs. _multiple for keys :)
                 return
                     <div class="property taxonomy-{$t('id')}">
-                        <div class="key">{(eutil:getLanguageString(edition:getLanguageFileURI($edition, $lang), 'view.window.AnnotationView_' || $t('label'), (), $lang), 'view.window.AnnotationView_' || $t('label'))[1]}</div>
+                        <div class="key">{(eutil:getLanguageString(edition:getLanguageFileURI($edition, $lang), $t('label'), (), $lang), $t('label'))[1]}</div>
                         <div class="value">{string-join($t('items')?*?name, ', ')}</div>
                     </div>
             }

--- a/data/xql/getAnnotationMeta.xql
+++ b/data/xql/getAnnotationMeta.xql
@@ -8,12 +8,14 @@ xquery version "3.1";
     Returns the HTML for a specific annotation for an AnnotationView.
 
     @author <a href="mailto:kepper@edirom.de">Johannes Kepper</a>
+    @author <a href="mailto:bohl@edirom.de">Benjamin W. Bohl</a>
 :)
 
 (: IMPORTS ================================================================= :)
 
 import module namespace annotation = "http://www.edirom.de/xquery/annotation" at "../xqm/annotation.xqm";
 import module namespace doc = "http://www.edirom.de/xquery/document" at "../xqm/document.xqm";
+import module namespace edition = "http://www.edirom.de/xquery/edition" at "../xqm/edition.xqm";
 import module namespace eutil = "http://www.edirom.de/xquery/eutil" at "../xqm/eutil.xqm";
 import module namespace source = "http://www.edirom.de/xquery/source" at "../xqm/source.xqm";
 import module namespace taxonomy = "http://www.edirom.de/xquery/taxonomy" at "../xqm/taxonomy.xqm";
@@ -39,6 +41,27 @@ let $annot := $doc/id($internalId)
 
 let $participants := annotation:getParticipants($annot)
 
+(: TODO deprecate below categories and priorities fields with Edirom-Online-API 2.0.0 :)
+let $hideLegacyFields := xs:boolean(edition:getPreference('annotation_hide_legacy_fields', $edition))
+let $priority := annotation:getPriorityLabel($annot)
+let $priorityLabel := switch ($priority)
+     case ""
+         return
+             ()
+     default return
+         eutil:getLanguageString('ediromPriority', ()) || ' (legacy)'
+
+ let $categories := annotation:get-category-labels-as-sequence($annot)
+ let $categoriesLabel :=
+    switch (count($categories))
+        case 0 return ()
+        case 1 return
+             eutil:getLanguageString('ediromCategory', ()) || ' (legacy)'
+        default return
+         eutil:getLanguageString('ediromCategory_multiple', ()) || ' (legacy)'
+
+(: TODO deprecate above categories and priorities fields with Edirom-Online-API 2.0.0 :)
+
 let $taxonomiesArray := annotation:get-referenced-categories-as-taxonomy-array($annot, $doc, $lang)
 
 let $sigla := source:getSiglaAsArray($participants)
@@ -57,11 +80,27 @@ return
     <div class="annotView">
         <div class="metaBox">
             {
+                if($hideLegacyFields) then
+                    ()
+                else (
+                    (: TODO deprecate priority field with Edirom-Online-API 2.0.0 :)
+                    <div class="property priority">
+                        <div class="key">{$priorityLabel}</div>
+                        <div class="value">{$priority}</div>
+                    </div>,
+                    (: TODO deprecate categories field with Edirom-Online-API 2.0.0 :)
+                    <div class="property categories">
+                        <div class="key">{$categoriesLabel}</div>
+                        <div class="value">{string-join($categories, ', ')}</div>
+                    </div>
+                )
+            }
+            {
                 for $t in $taxonomiesArray?*
                 (: TODO process single vs. _multiple for keys :)
                 return
                     <div class="property taxonomy-{$t('id')}">
-                        <div class="key">{$t('label')}</div>
+                        <div class="key">{(eutil:getLanguageString(edition:getLanguageFileURI($edition, $lang), 'view.window.AnnotationView_' || $t('label'), (), $lang), 'view.window.AnnotationView_' || $t('label'))[1]}</div>
                         <div class="value">{string-join($t('items')?*?name, ', ')}</div>
                     </div>
             }

--- a/data/xql/getAnnotationMeta.xql
+++ b/data/xql/getAnnotationMeta.xql
@@ -39,12 +39,10 @@ let $annot := $doc/id($internalId)
 
 let $participants := annotation:getParticipants($annot)
 
-let $classElements :=
-    for $classIDREF in annotation:get-class-idrefs-as-sequence($annot)
-    return $doc/id($classIDREF)
+let $categoryElements := annotation:get-referenced-category-elements($annot, $doc)
 
 let $taxonomyGroups :=
-    for $elem in $classElements[ancestor::mei:taxonomy]
+    for $elem in $categoryElements
     let $taxonomyId := taxonomy:get-parent-taxonomy-identifying-string($elem)
     group by $taxonomyId
     let $taxonomyElem := $elem[1]/ancestor-or-self::mei:taxonomy[1]

--- a/data/xql/getAnnotations.xql
+++ b/data/xql/getAnnotations.xql
@@ -7,41 +7,52 @@ xquery version "3.1";
 : Returns a JSON representation of all Annotations of a document.
 :
 : @author <a href="mailto:roewenstrunk@edirom.de">Daniel Röwenstrunk</a>
+: @author Benjamin W. Bohl <b.w.bohl@gmail.com>
 :)
+
 
 (: IMPORTS ================================================================= :)
 
 import module namespace annotation = "http://www.edirom.de/xquery/annotation" at "../xqm/annotation.xqm";
 import module namespace eutil = "http://www.edirom.de/xquery/eutil" at "../xqm/eutil.xqm";
 
+
 (: NAMESPACE DECLARATIONS ================================================== :)
 
-declare namespace request = "http://exist-db.org/xquery/request";
 declare namespace mei = "http://www.music-encoding.org/ns/mei";
+
 declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
+
+declare namespace request = "http://exist-db.org/xquery/request";
+
 
 (: OPTION DECLARATIONS ===================================================== :)
 
 declare option output:method "json";
+
 declare option output:media-type "application/json";
 
-let $edition := request:get-parameter('edition', '')
-let $uri := request:get-parameter('uri', '')
+
+(: VARIABLE DECLARATIONS =================================================== :)
+
+declare variable $EDITION := request:get-parameter('edition', '');
+
+declare variable $URI := request:get-parameter('uri', '');
+
+
+(: QUERY BODY ============================================================= :)
 
 let $uri :=
-    if (contains($uri, '#')) then
-        (substring-before($uri, '#'))
+    if (contains($URI, '#')) then
+        (substring-before($URI, '#'))
     else
-        ($uri)
+        ($URI)
 
 let $doc := eutil:getDoc($uri)
 
-let $map :=
+return
     map {
         'success': true(),
         'total': count($doc//mei:annot[@type = 'editorialComment']),
-        'annotations': array {annotation:annotationsToJSON($uri, $edition)}
+        'annotations': array {annotation:annotationsToJSON($uri, $EDITION)}
     }
-
-return
-    $map

--- a/data/xql/getAnnotations.xql
+++ b/data/xql/getAnnotations.xql
@@ -69,5 +69,6 @@ return
         'total': count($doc//mei:annot[@type = 'editorialComment']),
         'annotations': array {$annotations},
         'fields': $annotationFields,
-        'emptyFields': $emptyFields
+        'emptyFields': $emptyFields,
+        'legacyFields': array { 'categories', 'priority' }
     }

--- a/data/xql/getAnnotations.xql
+++ b/data/xql/getAnnotations.xql
@@ -50,9 +50,11 @@ let $uri :=
 
 let $doc := eutil:getDoc($uri)
 
+let $annotations := annotation:annotationsToJSON($uri, $EDITION)
+
 return
     map {
         'success': true(),
         'total': count($doc//mei:annot[@type = 'editorialComment']),
-        'annotations': array {annotation:annotationsToJSON($uri, $EDITION)}
+        'annotations': array {$annotations},
     }

--- a/data/xql/getAnnotations.xql
+++ b/data/xql/getAnnotations.xql
@@ -52,9 +52,12 @@ let $doc := eutil:getDoc($uri)
 
 let $annotations := annotation:annotationsToJSON($uri, $EDITION)
 
+let $annotationFields := map:keys($annotations[1])
+
 return
     map {
         'success': true(),
         'total': count($doc//mei:annot[@type = 'editorialComment']),
         'annotations': array {$annotations},
+        'fields': $annotationFields,
     }

--- a/data/xql/getAnnotations.xql
+++ b/data/xql/getAnnotations.xql
@@ -16,8 +16,6 @@ xquery version "3.1";
 import module namespace annotation = "http://www.edirom.de/xquery/annotation" at "../xqm/annotation.xqm";
 import module namespace eutil = "http://www.edirom.de/xquery/eutil" at "../xqm/eutil.xqm";
 
-import module namespace eutil = "http://www.edirom.de/xquery/eutil" at "../xqm/eutil.xqm";
-
 
 (: NAMESPACE DECLARATIONS ================================================== :)
 

--- a/data/xql/getAnnotations.xql
+++ b/data/xql/getAnnotations.xql
@@ -63,6 +63,10 @@ let $emptyFields :=
     )
     return $fieldName
 
+(: legacy fields are only superseded when taxonomy-derived fields are actually present in the data :)
+let $baseFields := ('id', 'title', 'categories', 'priority', 'pos', 'sigla')
+let $hasTaxonomyFields := some $f in $annotationFields satisfies not($f = $baseFields)
+
 return
     map {
         'success': true(),
@@ -70,5 +74,5 @@ return
         'annotations': array {$annotations},
         'fields': $annotationFields,
         'emptyFields': $emptyFields,
-        'legacyFields': array { 'categories', 'priority' }
+        'legacyFields': array { if ($hasTaxonomyFields) then ('categories', 'priority') else () }
     }

--- a/data/xql/getAnnotations.xql
+++ b/data/xql/getAnnotations.xql
@@ -54,7 +54,7 @@ let $doc := eutil:getDoc($uri)
 
 let $annotations := annotation:annotationsToJSON($uri, $EDITION)
 
-let $annotationFields := map:keys($annotations[1])
+let $annotationFields := distinct-values(for $a in $annotations return map:keys($a))
 
 let $emptyFields :=
     for $fieldName in $annotationFields

--- a/data/xql/getAnnotations.xql
+++ b/data/xql/getAnnotations.xql
@@ -16,6 +16,8 @@ xquery version "3.1";
 import module namespace annotation = "http://www.edirom.de/xquery/annotation" at "../xqm/annotation.xqm";
 import module namespace eutil = "http://www.edirom.de/xquery/eutil" at "../xqm/eutil.xqm";
 
+import module namespace eutil = "http://www.edirom.de/xquery/eutil" at "../xqm/eutil.xqm";
+
 
 (: NAMESPACE DECLARATIONS ================================================== :)
 
@@ -54,10 +56,18 @@ let $annotations := annotation:annotationsToJSON($uri, $EDITION)
 
 let $annotationFields := map:keys($annotations[1])
 
+let $emptyFields :=
+    for $fieldName in $annotationFields
+    where every $annotation in $annotations satisfies (
+        map:contains($annotation, $fieldName) and eutil:is-empty($annotation($fieldName))
+    )
+    return $fieldName
+
 return
     map {
         'success': true(),
         'total': count($doc//mei:annot[@type = 'editorialComment']),
         'annotations': array {$annotations},
         'fields': $annotationFields,
+        'emptyFields': $emptyFields
     }

--- a/data/xql/getAnnotationsOnPage.xql
+++ b/data/xql/getAnnotationsOnPage.xql
@@ -15,6 +15,7 @@ xquery version "3.1";
 
 import module namespace functx = "http://www.functx.com";
 
+import module namespace annotation = "http://www.edirom.de/xquery/annotation" at "../xqm/annotation.xqm";
 import module namespace edition = "http://www.edirom.de/xquery/edition" at "../xqm/edition.xqm";
 import module namespace eutil = "http://www.edirom.de/xquery/eutil" at "../xqm/eutil.xqm";
 
@@ -61,6 +62,8 @@ declare function local:getAnnotations($sourceUriSharp as xs:string, $surfaceId a
         
         let $cat := $annotation/mei:ptr[@type = "categories"]/replace(@target, '#', '') || string-join($classes[contains(., 'annotation.category.')], ' ')
         
+        let $taxonomyClasses := string-join(annotation:get-class-idrefs-as-sequence($annotation), ' ')
+
         let $plist.raw :=
             for $p in tokenize(normalize-space($annotation/@plist), ' ')
             let $p.noSharp := replace($p, '#', '')
@@ -84,7 +87,8 @@ declare function local:getAnnotations($sourceUriSharp as xs:string, $surfaceId a
                 'fn': 'loadLink("' || $uri || '")',
                 'uri': $uri,
                 'priority': $prio,
-                'categories': $cat
+                'categories': $cat,
+                'taxonomyClasses': $taxonomyClasses
             }
     }
 };

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -109,6 +109,10 @@ declare function annotation:toJSON($anno as element(), $edition as xs:string) as
     let $classes := annotation:get-class-idrefs-as-sequence($anno)
     let $catURIs := distinct-values((tokenize(replace($anno/mei:ptr[@type = 'categories']/@target,'#',''),' '), $classes[contains(.,'annotation.category.')]))
 
+    let $classes-elements :=
+        for $uri in $classes
+        return $doc/id($uri)
+
     let $cats :=
         string-join(
             for $u in $catURIs
@@ -125,8 +129,24 @@ declare function annotation:toJSON($anno as element(), $edition as xs:string) as
         'pos': string($count),
         'sigla': string-join($sigla,', ')
     }
+
+    (: create a map with keys for each taxonomy used for this annotation and the corresponding class labels :)
+    let $taxonomiesMap := map:merge(
+        for $usedTaxonomy in $classes-elements[ancestor::mei:taxonomy]
+        let $taxonomyIdentifier := taxonomy:get-root-identifying-string( $usedTaxonomy )
+        return
+            map:entry(
+                $taxonomyIdentifier,
+                for $classElement in $classes-elements[self::mei:category]
+                where taxonomy:get-root-identifying-string( $classElement ) = $taxonomyIdentifier
+                return taxonomy:get-label-localized-as-string($classElement))
+    )
+
     return
-            $baseMap
+        map:merge((
+            $baseMap,
+            $taxonomiesMap
+        ))
 };
 
 (:~

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -117,7 +117,7 @@ declare function annotation:toJSON($anno as element(), $edition as xs:string) as
     let $cats :=
         string-join(
             for $u in $catURIs
-            return annotation:get-category-label-localized($doc/id($u), eutil:getLanguage($edition))
+            return annotation:get-category-label-localized($doc/id($u))
          , ', ')
 
     let $count := count($anno/preceding::mei:annot[@type = 'editorialComment']) + 1
@@ -255,7 +255,7 @@ declare function annotation:get-category-labels-as-sequence($anno as element()) 
 
     let $cats :=
         for $u in $catURIs
-        return annotation:get-category-label-localized($doc/id($u),'')
+        return annotation:get-category-label-localized($doc/id($u))
 
     return $cats
 };

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -17,6 +17,8 @@ module namespace annotation = "http://www.edirom.de/xquery/annotation";
 import module namespace edition="http://www.edirom.de/xquery/edition" at "edition.xqm";
 import module namespace eutil="http://www.edirom.de/xquery/eutil" at "eutil.xqm";
 
+import module namespace taxonomy="http://www.edirom.de/xquery/taxonomy" at "taxonomy.xqm";
+
 (: NAMESPACE DECLARATIONS ================================================== :)
 
 declare namespace mei="http://www.music-encoding.org/ns/mei";
@@ -26,6 +28,34 @@ declare namespace transform="http://exist-db.org/xquery/transform";
 
 (: FUNCTION DECLARATIONS =================================================== :)
 
+<<<<<<< HEAD
+=======
+declare function annotation:getLocalizedLabel($node) {
+
+    let $lang := request:get-parameter('lang', '')
+    let $nodeName := local-name($node)
+  
+    let $label :=
+        if($nodeName = 'category') then (
+            (: new style, i.e. //category/label :)
+            let $labels := taxonomy:get-labels( $node )
+            return
+                if ($labels( $lang )) then
+                    $labels( $lang )
+                else
+                    $labels( 'und' )
+        
+        ) else if($nodeName = 'term') then(
+            (: old style, i.e. //term/name :)
+            eutil:getLocalizedName($node, $lang)
+        
+        ) else
+            ($nodeName)
+  
+    return $label
+};
+
+>>>>>>> 7e006fca (annotation.xqm: use new function  taxonomy:get-labels in getLocalizedLabel)
 (:~
  : Returns a JSON representation of all Annotations of a document
  :

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -257,6 +257,22 @@ declare function annotation:get-category-labels-as-sequence($anno as element()) 
 };
 
 (:~
+ : Gets the labels for an annotation’s classes
+ :
+ :@param element() mei:annot element
+ :@return sequence of xs:string, might be an empty sequence
+ :)
+declare function annotation:get-class-labels-as-sequence($anno as element(mei:annot)) as xs:string* {
+
+    (: TODO fix strict binding to definitions in the same file :)
+    let $doc := $anno/root()
+
+    for $classIDREF in annotation:get-class-idrefs-as-sequence($anno)
+    return annotation:get-category-label-localized($doc/id($classIDREF))
+
+};
+
+(:~
  : Gets the IDREFs for an annotation’s classes
  :
  :@param element() mei:annot element

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -28,7 +28,7 @@ declare namespace transform="http://exist-db.org/xquery/transform";
 
 (: FUNCTION DECLARATIONS =================================================== :)
 
-declare function annotation:getLocalizedLabel($node) {
+declare function annotation:get-category-label-localized($node) {
 
     let $lang := request:get-parameter('lang', '')
     let $nodeName := local-name($node)
@@ -204,7 +204,7 @@ declare function annotation:getPriorityLabel($anno) as xs:string* {
 
     return
         if($isPrioElemAlready) then
-            (eutil:getLocalizedName($anno))
+            (annotation:get-category-label-localized($anno))
 
         else if($oldEdiromStyle) then
             (annotation:getPriority($anno))
@@ -222,7 +222,7 @@ declare function annotation:getPriorityLabel($anno) as xs:string* {
                         eutil:getDoc(substring-before($uri,'#'))
                 
                 let $prioElem := $doc/id(replace($uri,'#',''))
-                let $label := eutil:getLocalizedName($prioElem)
+                let $label := annotation:get-category-label-localized($prioElem)
                 return $label
 
             return string-join($labels,', ')
@@ -272,4 +272,19 @@ declare function annotation:getParticipants($anno as element()) as xs:string* {
     let $uris := distinct-values(for $uri in $ps return substring-before($uri,'#'))
 
     return $uris
+};
+
+(:~
+ : Returns an annotation category's name
+ :
+ : @param $category The category to process
+ : @return one name
+ :)
+declare function annotation:category_getName($category as element(), $language as xs:string) {
+    annotation:get-category-label-localized($category)
+    (:let $names := $category/mei:name
+    return
+        switch (count($names[@xml:lang = $language]))
+            case 1 return $names[@xml:lang = $language]
+            default return $names[1]:)
 };

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -119,6 +119,8 @@ declare function annotation:toJSON($anno as element(), $edition as xs:string) as
             return annotation:get-category-label-localized($doc/id($u))
          , ', ')
 
+    let $categoryElements := annotation:get-referenced-category-elements($anno, edition:collection($edition))
+
     let $count := count($anno/preceding::mei:annot[@type = 'editorialComment']) + 1
 
     (: create a map with all static information about the annotation :)
@@ -131,14 +133,14 @@ declare function annotation:toJSON($anno as element(), $edition as xs:string) as
 
     (: create a map with keys for each taxonomy used for this annotation and the corresponding class labels :)
     let $taxonomiesMap := map:merge(
-        for $usedTaxonomy in $classes-elements[ancestor::mei:taxonomy]
+        for $usedTaxonomy in $categoryElements
         let $taxonomyIdentifier := taxonomy:get-parent-taxonomy-identifying-string( $usedTaxonomy )
         return
             map:entry(
                 $taxonomyIdentifier,
                 string-join (
                     (
-                        for $classElement in $classes-elements[self::mei:category]
+                        for $classElement in $categoryElements
                         where taxonomy:get-parent-taxonomy-identifying-string( $classElement ) = $taxonomyIdentifier
                         return taxonomy:get-label-localized-as-string($classElement)
                     ),
@@ -308,6 +310,33 @@ declare function annotation:get-class-idrefs-as-sequence($anno as element(mei:an
     for $token in $anno/@class => normalize-space() => replace('#','') => tokenize(' ')
     return xs:IDREF($token)
 
+};
+
+(:~
+ : Returns the mei:category elements referenced by @class on the given annotations,
+ : searching for taxonomy definitions within the given scope.
+ :
+ : Fragment IDs are extracted from all @class tokens that contain ‘#' (handles both
+ : plain fragment refs like ‘#someId' and relative URIs like ‘taxonomy.xml#someId').
+ : Tokens without ‘#' (bare external URIs) are silently ignored.
+ :
+ : @param $annots  One or more mei:annot elements to inspect
+ : @param $scope   Node(s) to search for mei:category definitions (typically edition:collection($edition))
+ : @return         Distinct mei:category elements, deduplicated by @xml:id (first occurrence wins)
+ :)
+declare function annotation:get-referenced-category-elements(
+    $annots as element(mei:annot)*,
+    $scope  as node()*
+) as element(mei:category)*
+{
+    let $ids := distinct-values(
+        for $annot in $annots
+        for $token in tokenize(normalize-space($annot/@class), ‘ ‘)[contains(., ‘#')]
+        return substring-after($token, ‘#')
+    )
+    let $raw := $scope//mei:category[@xml:id = $ids]
+    for $id in distinct-values($raw/@xml:id)
+    return ($raw[@xml:id = $id])[1]
 };
 
 (:~

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -273,18 +273,3 @@ declare function annotation:getParticipants($anno as element()) as xs:string* {
 
     return $uris
 };
-
-(:~
- : Returns an annotation category's name
- :
- : @param $category The category to process
- : @return one name
- :)
-declare function annotation:category_getName($category as element(), $language as xs:string) {
-    annotation:get-category-label-localized($category)
-    (:let $names := $category/mei:name
-    return
-        switch (count($names[@xml:lang = $language]))
-            case 1 return $names[@xml:lang = $language]
-            default return $names[1]:)
-};

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -257,6 +257,19 @@ declare function annotation:get-category-labels-as-sequence($anno as element()) 
 };
 
 (:~
+ : Gets the IDREFs for an annotation’s classes
+ :
+ :@param element() mei:annot element
+ :@return sequence of xs:IDREF, might be an empty sequence
+ :)
+declare function annotation:get-class-idrefs-as-sequence($anno as element(mei:annot)) as xs:IDREF* {
+
+    for $token in $anno/@class => normalize-space() => replace('#','') => tokenize(' ')
+    return xs:IDREF($token)
+
+};
+
+(:~
  : Returns a sequence of document URIs addressed by an annotation
  :
  : @param $anno element() The Annotation to process

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -316,9 +316,9 @@ declare function annotation:get-class-idrefs-as-sequence($anno as element(mei:an
  : Returns the mei:category elements referenced by @class on the given annotations,
  : searching for taxonomy definitions within the given scope.
  :
- : Fragment IDs are extracted from all @class tokens that contain ‘#' (handles both
- : plain fragment refs like ‘#someId' and relative URIs like ‘taxonomy.xml#someId').
- : Tokens without ‘#' (bare external URIs) are silently ignored.
+ : Fragment IDs are extracted from all @class tokens that contain '#' (handles both
+ : plain fragment refs like '#someId' and relative URIs like 'taxonomy.xml#someId').
+ : Tokens without '#' (bare external URIs) are silently ignored.
  :
  : @param $annots  One or more mei:annot elements to inspect
  : @param $scope   Node(s) to search for mei:category definitions (typically edition:collection($edition))
@@ -331,8 +331,8 @@ declare function annotation:get-referenced-category-elements(
 {
     let $ids := distinct-values(
         for $annot in $annots
-        for $token in tokenize(normalize-space($annot/@class), ‘ ‘)[contains(., ‘#')]
-        return substring-after($token, ‘#')
+        for $token in tokenize(normalize-space($annot/@class), ' ')[contains(., '#')]
+        return substring-after($token, '#')
     )
     let $raw := $scope//mei:category[@xml:id = $ids]
     for $id in distinct-values($raw/@xml:id)

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -190,6 +190,13 @@ declare function annotation:getPriority($anno as element()) as xs:string* {
             $locId
 };
 
+(:~
+ : Gets the label for a Edirom Online annotation priority
+ :
+ : @param $anno should be a mei:annot, mei:term, or mei:category element
+ :
+ : @return
+ :)
 declare function annotation:getPriorityLabel($anno) as xs:string* {
 
     let $isPrioElemAlready := local-name($anno) = ('term','category')
@@ -223,8 +230,6 @@ declare function annotation:getPriorityLabel($anno) as xs:string* {
 };
 
 (:~
-<<<<<<< HEAD
-=======
 : Returns Annotation's categories
 :
 : @param $anno The Annotation to process
@@ -236,19 +241,13 @@ declare function annotation:getCategories($anno as element()) as xs:string {
 };
 
 (:~
->>>>>>> d3feb43b (annotation.xqm: rename function)
- : Returns an array of Annotation's categories
+ : Returns a sequence of names/labels for an annotation's categories
  :
  : @param $anno The Annotation to process
  : @return The categories (as comma separated string)
  :)
-<<<<<<< HEAD
-declare function annotation:getCategoriesAsArray($anno as element()) as xs:string* {
-
-=======
 declare function annotation:get-category-labels-as-sequence($anno as element()) as xs:string* {
 
->>>>>>> d3feb43b (annotation.xqm: rename function)
     let $doc := $anno/root()
 
     let $classes := tokenize(replace(normalize-space($anno/@class),'#',''),' ')
@@ -262,10 +261,10 @@ declare function annotation:get-category-labels-as-sequence($anno as element()) 
 };
 
 (:~
- : Returns a list of URIs addressed by an Annotation
+ : Returns a sequence of document URIs addressed by an annotation
  :
- : @param $anno The Annotation to process
- : @return The list
+ : @param $anno element() The Annotation to process
+ : @return sequence of xs:string, might be an empty sequence
  :)
 declare function annotation:getParticipants($anno as element()) as xs:string* {
 

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -136,9 +136,15 @@ declare function annotation:toJSON($anno as element(), $edition as xs:string) as
         return
             map:entry(
                 $taxonomyIdentifier,
-                for $classElement in $classes-elements[self::mei:category]
-                where taxonomy:get-root-identifying-string( $classElement ) = $taxonomyIdentifier
-                return taxonomy:get-label-localized-as-string($classElement))
+                string-join (
+                    (
+                        for $classElement in $classes-elements[self::mei:category]
+                        where taxonomy:get-root-identifying-string( $classElement ) = $taxonomyIdentifier
+                        return taxonomy:get-label-localized-as-string($classElement)
+                    ),
+                    ', '
+                )
+            )
     )
 
     return

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -117,7 +117,7 @@ declare function annotation:toJSON($anno as element(), $edition as xs:string) as
     let $cats :=
         string-join(
             for $u in $catURIs
-            return eutil:getLocalizedName($doc/id($u), edition:getLanguage($edition))
+            return annotation:get-category-label-localized($doc/id($u), eutil:getLanguage($edition))
          , ', ')
 
     let $count := count($anno/preceding::mei:annot[@type = 'editorialComment']) + 1
@@ -255,7 +255,7 @@ declare function annotation:get-category-labels-as-sequence($anno as element()) 
 
     let $cats :=
         for $u in $catURIs
-        return annotation:category_getName($doc/id($u),'')
+        return annotation:get-category-label-localized($doc/id($u),'')
 
     return $cats
 };

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -352,3 +352,45 @@ declare function annotation:getParticipants($anno as element()) as xs:string* {
 
     return $uris
 };
+
+(:~
+ : Returns a map referenced classes in a map structured by taxonomy
+ :
+ : @param $annots one or more mei:annot elements
+ : @return a map
+ :)
+declare function annotation:get-referenced-categories-as-taxonomy-array(
+    $annots as element(mei:annot)+,
+    $scope as node()+,
+    $lang as xs:string?
+) as array(*)
+{
+    let $lang := eutil:getSetLanguage($lang)
+
+    return array {
+        for $annot in $annots
+        for $annotElement in ($scope//mei:annot[@xml:id = $annot/@xml:id])[1]
+        for $categoryElement in annotation:get-referenced-category-elements($annotElement)
+        let $taxonomyGroupingKey := taxonomy:get-parent-taxonomy-identifying-string($categoryElement)
+        group by $taxonomyGroupingKey
+        let $taxonomyElement := $categoryElement[1]/ancestor-or-self::mei:taxonomy[1]
+        let $taxonomyLabels := taxonomy:get-labels($taxonomyElement)
+        let $taxonomyDisplayLabel := ($taxonomyLabels($lang)[. != ''], $taxonomyLabels('und')[. != ''], $taxonomyGroupingKey)[1]
+        return
+            map {
+                'id': $taxonomyGroupingKey,
+                'label': $taxonomyDisplayLabel,
+                'items': array {
+                    for $id in distinct-values($categoryElement/@xml:id)
+                    let $catElem := ($categoryElement[@xml:id = $id])[1]
+                    let $catLabel := taxonomy:get-label-localized-as-string($catElem)
+                    order by $catLabel
+                    return
+                        map {
+                            'id': xs:string($id),
+                            'name': $catLabel
+                        }
+                }
+            }
+    }
+};

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -122,15 +122,16 @@ declare function annotation:toJSON($anno as element(), $edition as xs:string) as
 
     let $count := count($anno/preceding::mei:annot[@type = 'editorialComment']) + 1
 
+    let $baseMap := map {
+        'id': $id,
+        'title': normalize-space($title),
+        'categories': $cats,
+        'priority': $prio,
+        'pos': string($count),
+        'sigla': string-join($sigla,', ')
+    }
     return
-        map {
-            'id': $id,
-            'title': normalize-space($title),
-            'categories': $cats,
-            'priority': $prio,
-            'pos': string($count),
-            'sigla': string-join($sigla,', ')
-        }
+            $baseMap
 };
 
 (:~

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -125,6 +125,10 @@ declare function annotation:toJSON($anno as element(), $edition as xs:string) as
     let $baseMap := map {
         'id': $id,
         'title': normalize-space($title),
+        (: TODO deprecate categories field with Edirom-Online-API 2.0.0 :)
+        'categories': $cats,
+        (: TODO deprecate priority field with Edirom-Online-API 2.0.0 :)
+        'priority': $prio,
         'pos': string($count),
         'sigla': string-join($sigla,', ')
     }

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -106,7 +106,7 @@ declare function annotation:toJSON($anno as element(), $edition as xs:string) as
             else
                 ($pDoc//mei:title[@type = 'siglum']/text())
 
-    let $classes := tokenize(replace(normalize-space($anno/@class),'#',''),' ')
+    let $classes := annotation:get-class-idrefs-as-sequence($anno)
     let $catURIs := distinct-values((tokenize(replace($anno/mei:ptr[@type = 'categories']/@target,'#',''),' '), $classes[contains(.,'annotation.category.')]))
 
     let $cats :=

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -119,8 +119,6 @@ declare function annotation:toJSON($anno as element(), $edition as xs:string) as
             return annotation:get-category-label-localized($doc/id($u))
          , ', ')
 
-    let $categoryElements := annotation:get-referenced-category-elements($anno, edition:collection($edition))
-
     let $count := count($anno/preceding::mei:annot[@type = 'editorialComment']) + 1
 
     (: create a map with all static information about the annotation :)
@@ -133,14 +131,14 @@ declare function annotation:toJSON($anno as element(), $edition as xs:string) as
 
     (: create a map with keys for each taxonomy used for this annotation and the corresponding class labels :)
     let $taxonomiesMap := map:merge(
-        for $usedTaxonomy in $categoryElements
+        for $usedTaxonomy in $classes-elements[ancestor::mei:taxonomy]
         let $taxonomyIdentifier := taxonomy:get-parent-taxonomy-identifying-string( $usedTaxonomy )
         return
             map:entry(
                 $taxonomyIdentifier,
                 string-join (
                     (
-                        for $classElement in $categoryElements
+                        for $classElement in $classes-elements[self::mei:category]
                         where taxonomy:get-parent-taxonomy-identifying-string( $classElement ) = $taxonomyIdentifier
                         return taxonomy:get-label-localized-as-string($classElement)
                     ),

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -35,22 +35,20 @@ declare function annotation:getLocalizedLabel($node) {
     let $lang := request:get-parameter('lang', '')
     let $nodeName := local-name($node)
   
-    let $label :=
-        if($nodeName = 'category') then (
-            (: new style, i.e. //category/label :)
-            let $labels := taxonomy:get-labels( $node )
-            return
-                if ($labels( $lang )) then
-                    $labels( $lang )
-                else
-                    $labels( 'und' )
-        
-        ) else if($nodeName = 'term') then(
-            (: old style, i.e. //term/name :)
-            eutil:getLocalizedName($node, $lang)
-        
-        ) else
-            ($nodeName)
+     let $label :=
+        switch($nodeName)
+            case 'category' return
+                let $labels := taxonomy:get-labels( $node )
+                return
+                    if ( $labels( $lang ) ) then
+                        $labels( $lang )
+                    else
+                        $labels( 'und' )
+            case 'term' return
+                (: legacy way of associating categories and priorities to annotations using mei:ptr :)
+                eutil:getLocalizedName($node, $lang)
+            default return
+                $nodeName
   
     return $label
 };

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -373,36 +373,39 @@ declare function annotation:getParticipants($anno as element()) as xs:string* {
  : @return a map
  :)
 declare function annotation:get-referenced-categories-as-taxonomy-array(
-    $annots as element(mei:annot)+,
+    $annots as element(mei:annot)*,
     $scope as node()+,
     $lang as xs:string?
 ) as array(*)
 {
     let $lang := eutil:getSetLanguage($lang)
 
-    return array {
-        for $annot in $annots
-        for $annotElement in ($scope//mei:annot[@xml:id = $annot/@xml:id])[1]
-        for $categoryElement in annotation:get-referenced-category-elements($annotElement)
-        let $taxonomyGroupingKey := taxonomy:get-parent-taxonomy-identifying-string($categoryElement)
-        group by $taxonomyGroupingKey
-        let $taxonomyElement := $categoryElement[1]/ancestor-or-self::mei:taxonomy[1]
-        let $taxonomyDisplayLabel := (taxonomy:get-label-localized-as-string($taxonomyElement)[. != ''], $taxonomyGroupingKey)[1]
-        return
-            map {
-                'id': $taxonomyGroupingKey,
-                'label': $taxonomyDisplayLabel,
-                'items': array {
-                    for $id in distinct-values($categoryElement/@xml:id)
-                    let $catElem := ($categoryElement[@xml:id = $id])[1]
-                    let $catLabel := taxonomy:get-label-localized-as-string($catElem)
-                    order by $catLabel
-                    return
-                        map {
-                            'id': xs:string($id),
-                            'name': $catLabel
+    return
+        try {
+            array {
+                for $annot in $annots
+                for $annotElement in ($scope//mei:annot[@xml:id = $annot/@xml:id])[1]
+                for $categoryElement in annotation:get-referenced-category-elements($annotElement)
+                let $taxonomyGroupingKey := taxonomy:get-parent-taxonomy-identifying-string($categoryElement)
+                group by $taxonomyGroupingKey
+                let $taxonomyElement := $categoryElement[1]/ancestor-or-self::mei:taxonomy[1]
+                let $taxonomyDisplayLabel := (taxonomy:get-label-localized-as-string($taxonomyElement)[. != ''], $taxonomyGroupingKey)[1]
+                return
+                    map {
+                        'id': $taxonomyGroupingKey,
+                        'label': $taxonomyDisplayLabel,
+                        'items': array {
+                            for $id in distinct-values($categoryElement/@xml:id)
+                            let $catElem := ($categoryElement[@xml:id = $id])[1]
+                            let $catLabel := taxonomy:get-label-localized-as-string($catElem)
+                            order by $catLabel
+                            return
+                                map {
+                                    'id': xs:string($id),
+                                    'name': $catLabel
+                                }
                         }
-                }
+                    }
             }
-    }
+        } catch * {[]}
 };

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -235,10 +235,10 @@ declare function annotation:getPriorityLabel($anno) as xs:string* {
 : @param $anno The Annotation to process
 : @return The categories (as comma separated string)
 :)
-declare function annotation:getCategories($anno as element()) as xs:string {
+(:declare function annotation:getCategories($anno as element()) as xs:string {
 
     string-join(annotation:get-category-labels-as-sequence($anno), ', ')
-};
+};:)
 
 (:~
  : Returns a sequence of names/labels for an annotation's categories

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -132,14 +132,14 @@ declare function annotation:toJSON($anno as element(), $edition as xs:string) as
     (: create a map with keys for each taxonomy used for this annotation and the corresponding class labels :)
     let $taxonomiesMap := map:merge(
         for $usedTaxonomy in $classes-elements[ancestor::mei:taxonomy]
-        let $taxonomyIdentifier := taxonomy:get-root-identifying-string( $usedTaxonomy )
+        let $taxonomyIdentifier := taxonomy:get-parent-taxonomy-identifying-string( $usedTaxonomy )
         return
             map:entry(
                 $taxonomyIdentifier,
                 string-join (
                     (
                         for $classElement in $classes-elements[self::mei:category]
-                        where taxonomy:get-root-identifying-string( $classElement ) = $taxonomyIdentifier
+                        where taxonomy:get-parent-taxonomy-identifying-string( $classElement ) = $taxonomyIdentifier
                         return taxonomy:get-label-localized-as-string($classElement)
                     ),
                     ', '

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -73,7 +73,6 @@ declare function annotation:toJSON($anno as element(), $edition as xs:string) as
     let $lang := request:get-parameter('lang', '')
     let $title := eutil:getLocalizedName($anno, $lang)
 
-    let $doc := $anno/root()
     let $prio := annotation:getPriorityLabel($anno)
     let $pList.raw := distinct-values(tokenize(normalize-space($anno/@plist), ' '))
 
@@ -106,18 +105,12 @@ declare function annotation:toJSON($anno as element(), $edition as xs:string) as
             else
                 ($pDoc//mei:title[@type = 'siglum']/text())
 
-    let $classes := annotation:get-class-idrefs-as-sequence($anno)
-    let $catURIs := distinct-values((tokenize(replace($anno/mei:ptr[@type = 'categories']/@target,'#',''),' '), $classes[contains(.,'annotation.category.')]))
-
+    (: resolve all @class references (cross-file aware) for the taxonomy fields below :)
     let $classes-elements :=
-        for $uri in $classes
-        return $doc/id($uri)
+        for $token in tokenize(normalize-space($anno/@class), ' ')[. != '']
+        return eutil:get-referenced-element($anno, $token)
 
-    let $cats :=
-        string-join(
-            for $u in $catURIs
-            return annotation:get-category-label-localized($doc/id($u))
-         , ', ')
+    let $cats := string-join(annotation:get-category-labels-as-sequence($anno), ', ')
 
     let $count := count($anno/preceding::mei:annot[@type = 'editorialComment']) + 1
 
@@ -240,15 +233,8 @@ declare function annotation:getPriorityLabel($anno) as xs:string* {
 
             let $labels :=
                 for $uri in $classBasedUri
-                let $doc :=
-                    if(starts-with($uri,'#')) then
-                        $anno/root()
-                    else
-                        eutil:getDoc(substring-before($uri,'#'))
-                
-                let $prioElem := $doc/id(replace($uri,'#',''))
-                let $label := annotation:get-category-label-localized($prioElem)
-                return $label
+                let $prioElem := eutil:get-referenced-element($anno, $uri)
+                return annotation:get-category-label-localized($prioElem)
 
             return string-join($labels,', ')
         )
@@ -273,16 +259,12 @@ declare function annotation:getPriorityLabel($anno) as xs:string* {
  :)
 declare function annotation:get-category-labels-as-sequence($anno as element()) as xs:string* {
 
-    let $doc := $anno/root()
+    let $ptrTokens := tokenize(normalize-space($anno/mei:ptr[@type = 'categories']/@target), ' ')
+    let $classTokens := tokenize(normalize-space($anno/@class), ' ')[contains(., 'annotation.category.')]
+    let $catTokens := distinct-values(($ptrTokens, $classTokens)[. != ''])
 
-    let $classes := tokenize(replace(normalize-space($anno/@class),'#',''),' ')
-    let $catURIs := distinct-values((tokenize(replace($anno/mei:ptr[@type = 'categories']/@target,'#',''),' '), $classes[contains(.,'annotation.category.')]))
-
-    let $cats :=
-        for $u in $catURIs
-        return annotation:get-category-label-localized($doc/id($u))
-
-    return $cats
+    for $token in $catTokens
+    return annotation:get-category-label-localized(eutil:get-referenced-element($anno, $token))
 };
 
 (:~
@@ -293,11 +275,8 @@ declare function annotation:get-category-labels-as-sequence($anno as element()) 
  :)
 declare function annotation:get-class-labels-as-sequence($anno as element(mei:annot)) as xs:string* {
 
-    (: TODO fix strict binding to definitions in the same file :)
-    let $doc := $anno/root()
-
-    for $classIDREF in annotation:get-class-idrefs-as-sequence($anno)
-    return annotation:get-category-label-localized($doc/id($classIDREF))
+    for $token in tokenize(normalize-space($anno/@class), ' ')[. != '']
+    return annotation:get-category-label-localized(eutil:get-referenced-element($anno, $token))
 
 };
 
@@ -317,11 +296,8 @@ declare function annotation:get-class-idrefs-as-sequence($anno as element(mei:an
 (:~
  : Returns the mei:category elements referenced by @class on the given annotations.
  :
- : Each URI token in @class is resolved to its target document before searching:
- : - fragment-only refs (#someId) resolve to the annotation's own document
- : - relative or absolute refs (taxonomy.xml#someId, http://…#someId) are resolved
- :   against the annotation's base URI and opened with doc()
- : Tokens without '#' (bare external URIs without a fragment) are silently ignored.
+ : Each @class token is resolved via eutil:get-referenced-element (cross-file aware) and
+ : kept only if it resolves to a mei:category.
  :
  : @param $annots  One or more mei:annot elements to inspect
  : @return         Distinct mei:category elements, deduplicated by @xml:id (first occurrence wins)
@@ -333,19 +309,7 @@ declare function annotation:get-referenced-category-elements(
     let $raw :=
         for $annot in $annots
         for $token in tokenize(normalize-space($annot/@class), ' ')[contains(., '#')]
-
-        let $base-part := substring-before($token, '#')
-
-        let $id        := substring-after($token, '#')
-
-        let $doc :=
-            if ($base-part = '')
-            then $annot/root()
-            else
-                let $resolved := resolve-uri($base-part, base-uri($annot))
-                return if (doc-available($resolved)) then doc($resolved) else ()
-
-        return $doc//mei:category[@xml:id = $id]
+        return eutil:get-referenced-element($annot, $token)[self::mei:category]
 
     for $id in distinct-values($raw/@xml:id)
 

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -121,6 +121,7 @@ declare function annotation:toJSON($anno as element(), $edition as xs:string) as
 
     let $count := count($anno/preceding::mei:annot[@type = 'editorialComment']) + 1
 
+    (: create a map with all static information about the annotation :)
     let $baseMap := map {
         'id': $id,
         'title': normalize-space($title),

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -313,29 +313,40 @@ declare function annotation:get-class-idrefs-as-sequence($anno as element(mei:an
 };
 
 (:~
- : Returns the mei:category elements referenced by @class on the given annotations,
- : searching for taxonomy definitions within the given scope.
+ : Returns the mei:category elements referenced by @class on the given annotations.
  :
- : Fragment IDs are extracted from all @class tokens that contain '#' (handles both
- : plain fragment refs like '#someId' and relative URIs like 'taxonomy.xml#someId').
- : Tokens without '#' (bare external URIs) are silently ignored.
+ : Each URI token in @class is resolved to its target document before searching:
+ : - fragment-only refs (#someId) resolve to the annotation's own document
+ : - relative or absolute refs (taxonomy.xml#someId, http://…#someId) are resolved
+ :   against the annotation's base URI and opened with doc()
+ : Tokens without '#' (bare external URIs without a fragment) are silently ignored.
  :
  : @param $annots  One or more mei:annot elements to inspect
- : @param $scope   Node(s) to search for mei:category definitions (typically edition:collection($edition))
  : @return         Distinct mei:category elements, deduplicated by @xml:id (first occurrence wins)
  :)
 declare function annotation:get-referenced-category-elements(
-    $annots as element(mei:annot)*,
-    $scope  as node()*
+    $annots as element(mei:annot)*
 ) as element(mei:category)*
 {
-    let $ids := distinct-values(
+    let $raw :=
         for $annot in $annots
         for $token in tokenize(normalize-space($annot/@class), ' ')[contains(., '#')]
-        return substring-after($token, '#')
-    )
-    let $raw := $scope//mei:category[@xml:id = $ids]
+
+        let $base-part := substring-before($token, '#')
+
+        let $id        := substring-after($token, '#')
+
+        let $doc :=
+            if ($base-part = '')
+            then $annot/root()
+            else
+                let $resolved := resolve-uri($base-part, base-uri($annot))
+                return if (doc-available($resolved)) then doc($resolved) else ()
+
+        return $doc//mei:category[@xml:id = $id]
+
     for $id in distinct-values($raw/@xml:id)
+
     return ($raw[@xml:id = $id])[1]
 };
 

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -28,13 +28,11 @@ declare namespace transform="http://exist-db.org/xquery/transform";
 
 (: FUNCTION DECLARATIONS =================================================== :)
 
-<<<<<<< HEAD
-=======
 declare function annotation:getLocalizedLabel($node) {
 
     let $lang := request:get-parameter('lang', '')
     let $nodeName := local-name($node)
-  
+
      let $label :=
         switch($nodeName)
             case 'category' return
@@ -49,11 +47,10 @@ declare function annotation:getLocalizedLabel($node) {
                 eutil:getLocalizedName($node, $lang)
             default return
                 $nodeName
-  
+
     return $label
 };
 
->>>>>>> 7e006fca (annotation.xqm: use new function  taxonomy:get-labels in getLocalizedLabel)
 (:~
  : Returns a JSON representation of all Annotations of a document
  :
@@ -226,13 +223,32 @@ declare function annotation:getPriorityLabel($anno) as xs:string* {
 };
 
 (:~
+<<<<<<< HEAD
+=======
+: Returns Annotation's categories
+:
+: @param $anno The Annotation to process
+: @return The categories (as comma separated string)
+:)
+declare function annotation:getCategories($anno as element()) as xs:string {
+
+    string-join(annotation:get-category-labels-as-sequence($anno), ', ')
+};
+
+(:~
+>>>>>>> d3feb43b (annotation.xqm: rename function)
  : Returns an array of Annotation's categories
  :
  : @param $anno The Annotation to process
  : @return The categories (as comma separated string)
  :)
+<<<<<<< HEAD
 declare function annotation:getCategoriesAsArray($anno as element()) as xs:string* {
 
+=======
+declare function annotation:get-category-labels-as-sequence($anno as element()) as xs:string* {
+
+>>>>>>> d3feb43b (annotation.xqm: rename function)
     let $doc := $anno/root()
 
     let $classes := tokenize(replace(normalize-space($anno/@class),'#',''),' ')

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -124,8 +124,6 @@ declare function annotation:toJSON($anno as element(), $edition as xs:string) as
     let $baseMap := map {
         'id': $id,
         'title': normalize-space($title),
-        'categories': $cats,
-        'priority': $prio,
         'pos': string($count),
         'sigla': string-join($sigla,', ')
     }

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -36,12 +36,7 @@ declare function annotation:get-category-label-localized($node) {
      let $label :=
         switch($nodeName)
             case 'category' return
-                let $labels := taxonomy:get-labels( $node )
-                return
-                    if ( $labels( $lang ) ) then
-                        $labels( $lang )
-                    else
-                        $labels( 'und' )
+                taxonomy:get-label-localized-as-string($node)
             case 'term' return
                 (: legacy way of associating categories and priorities to annotations using mei:ptr :)
                 eutil:getLocalizedName($node, $lang)

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -48,15 +48,15 @@ declare function annotation:annotationsToJSON($uri as xs:string, $edition as xs:
  : @return The JSON representation
  :)
 declare function annotation:toJSON($anno as element(), $edition as xs:string) as map(*) {
-    
+
     let $id := $anno/string(@xml:id)
     let $lang := request:get-parameter('lang', '')
     let $title := eutil:getLocalizedName($anno, $lang)
-    
+
     let $doc := $anno/root()
     let $prio := annotation:getPriorityLabel($anno)
     let $pList.raw := distinct-values(tokenize(normalize-space($anno/@plist), ' '))
-    
+
     let $pList :=
         for $p in $pList.raw
         return
@@ -64,7 +64,7 @@ declare function annotation:toJSON($anno as element(), $edition as xs:string) as
                 (substring-before($p, '#'))
             else
                 $p
-    
+
     let $sigla :=
         for $p in distinct-values($pList)
         let $pDoc.valid :=
@@ -85,18 +85,18 @@ declare function annotation:toJSON($anno as element(), $edition as xs:string) as
                 ($pDoc//mei:manifestationList/mei:manifestation/mei:identifier[@type = 'siglum']/text())
             else
                 ($pDoc//mei:title[@type = 'siglum']/text())
-    
+
     let $classes := tokenize(replace(normalize-space($anno/@class),'#',''),' ')
     let $catURIs := distinct-values((tokenize(replace($anno/mei:ptr[@type = 'categories']/@target,'#',''),' '), $classes[contains(.,'annotation.category.')]))
-    
+
     let $cats :=
         string-join(
             for $u in $catURIs
             return eutil:getLocalizedName($doc/id($u), edition:getLanguage($edition))
          , ', ')
-     
+
     let $count := count($anno/preceding::mei:annot[@type = 'editorialComment']) + 1
-    
+
     return
         map {
             'id': $id,
@@ -120,11 +120,11 @@ declare function annotation:getContent($anno as element(), $idPrefix as xs:strin
     let $edition := request:get-parameter('edition', '')
     let $imageserver :=  edition:getPreference('image_server', $edition)
     let $imageBasePath := edition:getPreference('image_prefix', $edition)
-    
+
     let $language := edition:getLanguage($edition)
-    
+
     let $p := $anno/mei:p[not(@xml:lang) or @xml:lang = $language]
-    
+
     let $html :=
         transform:transform($p,eutil:getDoc($eutil:xsltBase || '/meiP2html.xsl'),
             <parameters>
@@ -132,7 +132,7 @@ declare function annotation:getContent($anno as element(), $idPrefix as xs:strin
                 <param name="imagePrefix" value="{$imageBasePath}"/>
             </parameters>
         )
-    
+
     return
         $html
 };
@@ -144,7 +144,7 @@ declare function annotation:getContent($anno as element(), $idPrefix as xs:strin
  : @return The priority
  :)
 declare function annotation:getPriority($anno as element()) as xs:string* {
-    
+
     let $uri := $anno/mei:ptr[@type eq 'priority']/string(@target)
     let $lang := request:get-parameter('lang', '')
 
@@ -155,9 +155,9 @@ declare function annotation:getPriority($anno as element()) as xs:string* {
             eutil:getDoc(substring-before($uri,'#'))
     
     let $locId := substring-after($uri,'#')
-    
+
     let $elem := $doc/id($locId)
-    
+
     return
         if(local-name($elem) eq 'term') then
             eutil:getLocalizedName($elem, $lang)
@@ -166,21 +166,21 @@ declare function annotation:getPriority($anno as element()) as xs:string* {
 };
 
 declare function annotation:getPriorityLabel($anno) as xs:string* {
-    
+
     let $isPrioElemAlready := local-name($anno) = ('term','category')
     let $oldEdiromStyle := local-name($anno) = 'annot' and exists($anno/mei:ptr[@type eq 'priority'])
-    
+
     return
         if($isPrioElemAlready) then
             (eutil:getLocalizedName($anno))
-        
+
         else if($oldEdiromStyle) then
             (annotation:getPriority($anno))
-        
+
         else (
             let $classes := tokenize(normalize-space($anno/@class),' ')
             let $classBasedUri := $classes[starts-with(.,'#ediromAnnotPrio')]
-            
+
             let $labels :=
                 for $uri in $classBasedUri
                 let $doc :=
@@ -192,7 +192,7 @@ declare function annotation:getPriorityLabel($anno) as xs:string* {
                 let $prioElem := $doc/id(replace($uri,'#',''))
                 let $label := eutil:getLocalizedName($prioElem)
                 return $label
-            
+
             return string-join($labels,', ')
         )
 };
@@ -204,30 +204,16 @@ declare function annotation:getPriorityLabel($anno) as xs:string* {
  : @return The categories (as comma separated string)
  :)
 declare function annotation:getCategoriesAsArray($anno as element()) as xs:string* {
-    
+
     let $doc := $anno/root()
-    
+
     let $classes := tokenize(replace(normalize-space($anno/@class),'#',''),' ')
     let $catURIs := distinct-values((tokenize(replace($anno/mei:ptr[@type = 'categories']/@target,'#',''),' '), $classes[contains(.,'annotation.category.')]))
-    
+
     let $cats :=
         for $u in $catURIs
-        return eutil:getLocalizedName($doc/id($u), '')
-                 
-    
-    (:let $uris := tokenize($anno/mei:ptr[@type eq 'categories']/string(@target),' ')
-    
-    let $string := for $uri in $uris
-                   let $doc := if(starts-with($uri,'#'))
-                               then($anno/root())
-                               else(eutil:getDoc(substring-before($uri,'#')))
-                   let $locID := substring-after($uri,'#')
-                   let $elem := $doc/id($locID)
-                   return
-                       if(local-name($elem) eq 'term')
-                       then(eutil:getLocalizedName($elem))
-                       else($locID)
-    :)
+        return annotation:category_getName($doc/id($u),'')
+
     return $cats
 };
 
@@ -238,9 +224,9 @@ declare function annotation:getCategoriesAsArray($anno as element()) as xs:strin
  : @return The list
  :)
 declare function annotation:getParticipants($anno as element()) as xs:string* {
-    
+
     let $ps := tokenize($anno/@plist, ' ')
     let $uris := distinct-values(for $uri in $ps return substring-before($uri,'#'))
-    
+
     return $uris
 };

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -383,8 +383,7 @@ declare function annotation:get-referenced-categories-as-taxonomy-array(
         let $taxonomyGroupingKey := taxonomy:get-parent-taxonomy-identifying-string($categoryElement)
         group by $taxonomyGroupingKey
         let $taxonomyElement := $categoryElement[1]/ancestor-or-self::mei:taxonomy[1]
-        let $taxonomyLabels := taxonomy:get-labels($taxonomyElement)
-        let $taxonomyDisplayLabel := ($taxonomyLabels($lang)[. != ''], $taxonomyLabels('und')[. != ''], $taxonomyGroupingKey)[1]
+        let $taxonomyDisplayLabel := (taxonomy:get-label-localized-as-string($taxonomyElement)[. != ''], $taxonomyGroupingKey)[1]
         return
             map {
                 'id': $taxonomyGroupingKey,

--- a/data/xqm/eutil.xqm
+++ b/data/xqm/eutil.xqm
@@ -259,6 +259,32 @@ declare %private function eutil:isInternalDbUri($uri as xs:string) as xs:boolean
 };
 
 (:~
+ : Resolves a single reference token to its target element(s) by id, honouring cross-file references.
+ :
+ : - a fragment-only token (#someId), or a bare id without '#', resolves within $node's own document
+ : - a token with a base part (other.xml#someId, http://…#someId) is resolved against $node's
+ :   base URI and loaded via eutil:getDoc (empty if that document is unavailable)
+ :
+ : @param $node      a node from the referencing document (provides the base URI / root)
+ : @param $reference a single, space-free reference token, with or without a leading '#'
+ : @return the element(s) the reference's id resolves to (empty if unresolvable)
+ :)
+declare function eutil:get-referenced-element($node as node(), $reference as xs:string) as element()* {
+    let $reference := normalize-space($reference)
+    return
+        if($reference eq "") then ()
+        else
+            let $hasHash := contains($reference, '#')
+            let $base    := if($hasHash) then substring-before($reference, '#') else ''
+            let $id      := if($hasHash) then substring-after($reference, '#') else $reference
+            let $doc :=
+                if($base eq '')
+                then $node/root()
+                else eutil:getDoc(xs:string(resolve-uri($base, base-uri($node))))
+            return $doc/id($id)
+};
+
+(:~
  : Returns a part's label (translated if available)
  :
  : @author Dennis Ried

--- a/data/xqm/eutil.xqm
+++ b/data/xqm/eutil.xqm
@@ -489,6 +489,28 @@ declare function eutil:compute-measure-sort-key( $key as xs:string ) as xs:strin
 
 
 (:~
+ : Checks if an item is considered empty according to various criteria.
+ : An item is considered empty if it is:
+ : - An empty sequence ()
+ : - An empty string ""
+ : - A sequence containing only one empty string ("")
+ : - An empty array []
+ : - An empty map map{}
+ :
+ : @param $item the item to check for emptiness
+ : @return true if the item is empty, false otherwise
+ :)
+declare function eutil:is-empty($item) as xs:boolean {
+
+    empty($item) or
+    ($item instance of xs:string and $item = "") or
+    (count($item) = 1 and $item instance of xs:string and $item = "") or
+    ($item instance of array(*) and array:size($item) = 0) or
+    ($item instance of map(*) and map:size($item) = 0)
+
+};
+
+(:~
  : Extracts an ISO 639 language code from a given ISO 3166-1 language code
  :
  : @author Benjamin W. Bohl

--- a/data/xqm/taxonomy.xqm
+++ b/data/xqm/taxonomy.xqm
@@ -143,6 +143,19 @@ as map( * )
 
 };
 
+declare function taxonomy:get-label-localized-as-string( $element as element( mei:category ) )
+as xs:string
+{
+    let $lang := request:get-parameter( 'lang', $eutil:lang )
+    let $labels := taxonomy:get-labels( $element )
+    return
+        if ( $labels( $lang ) ) then
+            $labels( $lang )
+        else
+            $labels( 'und' )
+
+};
+
 (:~
  : Returns labels of a mei:taxonomy or mei:category element.
  : This is the 1-arity version.

--- a/data/xqm/taxonomy.xqm
+++ b/data/xqm/taxonomy.xqm
@@ -92,7 +92,7 @@ as map( * )
     return
         map {
             "descs": taxonomy:get-descs( $element, $languages ),
-(:            "i18n": eutil:getLanguageString($EDITION, $idString, (), $eutil:lang), :)
+(:          "i18n": eutil:getLanguageString($EDITION, $idString, (), $eutil:lang), :)
             "id": $idString,
             "label":taxonomy:get-labels( $element ),
             "languages": taxonomy:get-languages( $element ),

--- a/data/xqm/taxonomy.xqm
+++ b/data/xqm/taxonomy.xqm
@@ -143,6 +143,18 @@ as map( * )
 
 };
 
+(:~
+ : Gets either the xml:id of the ancestor mei:taxonomy or the id referenced in @class
+ :
+ : @return xs:string of the retrieved identifer
+ :)
+declare function taxonomy:get-root-identifying-string( $element as element ( * ) )
+as xs:string
+{ (:TODO should precendence be as is or class over xml:id? :)
+    ($element/ancestor-or-self::mei:taxonomy/@xml:id, substring-after($element/@class, '#'))[1] => xs:string()
+
+};
+
 declare function taxonomy:get-label-localized-as-string( $element as element( mei:category ) )
 as xs:string
 {

--- a/data/xqm/taxonomy.xqm
+++ b/data/xqm/taxonomy.xqm
@@ -178,7 +178,7 @@ as xs:string
 declare function taxonomy:get-labels( $element as element( * ) )
 as map ( * )
 {
-    let $element :=  taxonomy:taxonomy-or-category-test( $element )
+    let $element := taxonomy:taxonomy-or-category-test( $element )
 
     return
         taxonomy:get-labels( $element, array{} )

--- a/data/xqm/taxonomy.xqm
+++ b/data/xqm/taxonomy.xqm
@@ -96,7 +96,7 @@ as map( * )
             "id": $idString,
             "label":taxonomy:get-labels( $element ),
             "languages": taxonomy:get-languages( $element ),
-            "taxonomy": ($element/ancestor::mei:taxonomy/@xml:id, substring-after($element/@class, '#'))[1] => xs:string()
+            "taxonomy": taxonomy:get-root-identifying-string( $element )
         }
 
 };

--- a/data/xqm/taxonomy.xqm
+++ b/data/xqm/taxonomy.xqm
@@ -211,7 +211,16 @@ as map ( * )
             for $lang at $i in array:flatten( $languages )
             return
                 switch ( $lang )
-                    case "und" return map:entry( "und", ( ( $element/mei:label[ not (@xml:lang ) ] )[ 1 ], $element/@label )[ 1 ] )
+                    case "und" return
+                        map:entry(
+                            "und",
+                            ( (: pick the first of the following :)
+                                (: the first mei:label without @xml:lang :)
+                                ( $element/mei:label[ not (@xml:lang ) ] )[ 1 ],
+                                (: the @label :)
+                                $element/@label,
+                                (: the first mei:label :)
+                                ( $element/mei:label )[ 1 ] )[ 1 ] => normalize-space() )
                     default return
                       map:entry( $lang, $element/mei:label[ @xml:lang = $lang ] => normalize-space() )
         )

--- a/data/xqm/taxonomy.xqm
+++ b/data/xqm/taxonomy.xqm
@@ -194,10 +194,7 @@ as xs:string
 
     let $labels := taxonomy:get-labels( $element )
     return
-        if ( $labels( $lang ) ) then
-            $labels( $lang )
-        else
-            $labels( 'und' )
+        ($labels($lang)[. != ''], $labels('und')[. != ''], xs:string($element/@xml:id))[1]
 
 };
 

--- a/data/xqm/taxonomy.xqm
+++ b/data/xqm/taxonomy.xqm
@@ -228,7 +228,19 @@ as map ( * )
 };
 
 (:~
- : Returns labels of a mei:taxonomy or mei:category element for given languages.
+ : Returns labels of a mei:taxonomy or mei:category element for given languages. If the
+ : submitted $languages array is empty an array for all available localizations will be
+ : returnd with an additional label for the 'und' (undefined) localization. The value for this
+ : will be determined in the following order:
+ :     1. child mei:label without @xml:lang (only possible on mei:category)
+ :     2. @label
+ :     3. first of all mei:label child elements (only possible on mei:category)
+ :     4. the element's own @xml:id
+ :     5. the parent taxonomy's identifying string
+ :
+ : Note: a mei:category that is referenced from mei:annot/@class is always resolvable by id()
+ : and therefore always carries an @xml:id, so step 5 is only ever reached for a mei:taxonomy
+ : that lacks its own @xml:id.
  :
  : @param $element a mei:taxonomy or mei:category element
  : @param $languages array(*) an array with language codes
@@ -257,12 +269,16 @@ as map ( * )
                         map:entry(
                             "und",
                             ( (: pick the first of the following :)
-                                (: the first mei:label without @xml:lang :)
+                                (: the first mei:label without @xml:lang – only available in mei:catgory :)
                                 ( $element/mei:label[ not (@xml:lang ) ] )[ 1 ],
                                 (: the @label :)
                                 $element/@label,
-                                (: the first mei:label :)
-                                ( $element/mei:label )[ 1 ] )[ 1 ] => normalize-space() )
+                                (: the first mei:label – only available in mei :category :)
+                                ( $element/mei:label )[ 1 ],
+                                (: the element’s xml:id :)
+                                $element/@xml:id,
+                                (: the parent taxonomy’s identifying string :)
+                                taxonomy:get-parent-taxonomy-identifying-string( $element ) )[ 1 ] => normalize-space() )
                     default return
                       map:entry( $lang, $element/mei:label[ @xml:lang = $lang ] => normalize-space() )
         )

--- a/data/xqm/taxonomy.xqm
+++ b/data/xqm/taxonomy.xqm
@@ -187,7 +187,7 @@ as xs:string
 
 };
 
-declare function taxonomy:get-label-localized-as-string( $element as element( mei:category ) )
+declare function taxonomy:get-label-localized-as-string( $element as element( * ) )
 as xs:string
 {
     let $lang := eutil:getSetLanguage(())

--- a/data/xqm/taxonomy.xqm
+++ b/data/xqm/taxonomy.xqm
@@ -187,6 +187,17 @@ as xs:string
 
 };
 
+(:~
+ : Returns a localized label string for a mei:taxonomy or mei:category element.
+ :
+ : Resolution order:
+ : 1. mei:label matching the current language
+ : 2. mei:label without @xml:lang (language-neutral)
+ : 3. @xml:id of the element as last resort
+ :
+ : @param $element a mei:taxonomy or mei:category element
+ : @return xs:string — never empty if the element has @xml:id
+ :)
 declare function taxonomy:get-label-localized-as-string( $element as element( * ) )
 as xs:string
 {

--- a/data/xqm/taxonomy.xqm
+++ b/data/xqm/taxonomy.xqm
@@ -175,17 +175,15 @@ as xs:string
  : Returns a string identifier for grouping a category with its siblings.
  :
  : Resolution order:
- : 1. @class fragment — use when it references the grouping parent category
- :    (e.g. edirom-style: class="#ediromPriority"; bazga-style: class="#bazga.annotation.class.editorial-intervention").
- : 2. The xml:id of the nearest ancestor mei:taxonomy as a fallback for
- :    categories that carry no @class.
+ : 1. @class fragment — the leaf category’s explicit declaration of its parent group
+ : 2. @xml:id of the nearest ancestor mei:taxonomy — fallback for elements without @class
  :
  : @return xs:string of the retrieved identifier
  :)
 declare function taxonomy:get-parent-taxonomy-identifying-string( $element as element( * ) )
 as xs:string
 {
-    (substring-after($element/@class, '#'), $element/ancestor-or-self::mei:taxonomy[last()]/@xml:id)[. != ''][1] => xs:string()
+    (substring-after($element/@class, '#'), $element/ancestor-or-self::mei:taxonomy[1]/@xml:id)[. != ''][1] => xs:string()
 
 };
 

--- a/data/xqm/taxonomy.xqm
+++ b/data/xqm/taxonomy.xqm
@@ -1,0 +1,214 @@
+xquery version "3.1";
+
+(:
+ : For LICENSE-Details please refer to the LICENSE file in the root directory of this repository.
+ :)
+
+(:~
+ : This module provides library functions for handlin MEI taxonomies
+ :
+ : @author Benjamin W. Bohl <b.w.bohl@gmail.com>
+ :)
+
+module namespace taxonomy = "http://www.edirom.de/xquery/taxonomy";
+
+
+(: IMPORTS ================================================================= :)
+
+import module namespace eutil="http://www.edirom.de/xquery/eutil" at "eutil.xqm";
+
+
+(: NAMESPACE DECLARATIONS ================================================== :)
+
+declare namespace mei="http://www.music-encoding.org/ns/mei";
+
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
+
+declare namespace request = "http://exist-db.org/xquery/request";
+
+
+(: FUNCTION DECLARATIONS =================================================== :)
+
+(:~
+ : Returns metadata about an mei:taxonomy
+ : 
+ : @param $element Anmei:taxonomy or mei:category element
+ :)
+declare function taxonomy:get-metadata( $element as element( * ) )
+as map( * )
+{
+    let $element :=  taxonomy:taxonomy-or-category-test( $element )
+    
+    let $idString := $element/@xml:id => xs:string()
+    
+    let $languages := taxonomy:get-languages( $element )
+    
+    return
+        map {
+            "categories": taxonomy:get-categories( $element ),
+            "descs": taxonomy:get-descs( $element, $languages ),
+            "heads": taxonomy:get-heads( $element, $languages ),
+(:            "i18n": eutil:getLanguageString($EDITION, $idString, (), $eutil:lang),:)
+            "id": $idString,
+            "label":taxonomy:get-labels( $element ),
+            "languages": taxonomy:get-languages( $element )
+        }
+    
+};
+
+declare function taxonomy:get-categories( $element as element( * ) )
+as array( * )*
+{
+    let $element :=  taxonomy:taxonomy-or-category-test( $element )
+    return
+        array {
+            for $category in $element/mei:category
+            return
+                taxonomy:get-metadata( $category )
+        }
+
+};
+
+declare function taxonomy:get-category( $element as element( mei:category ) )
+as map( * )
+{
+    let $idString := $element/@xml:id => xs:string()
+    
+    let $languages := taxonomy:get-languages( $element )
+    
+    return
+        map {
+            "descs": taxonomy:get-descs( $element, $languages ),
+(:            "i18n": eutil:getLanguageString($EDITION, $idString, (), $eutil:lang),:)
+            "id": $idString,
+            "label":taxonomy:get-labels( $element ),
+            "languages": taxonomy:get-languages( $element ),
+            "taxonomy": $element/ancestor::mei:taxonomy/@xml:id => xs:string()
+        }
+
+};
+
+(:~
+ : Returns the string content of mei:desc elements in mei:taxonomy or mei:category
+ : as map, with the language codes as keys.
+ :
+ : @param $element a mei:taxonomy or mei:category element
+ :)
+declare function taxonomy:get-descs( $element as element( * ), $languages as array( * ) )
+as map( * )
+{
+    let $element :=  taxonomy:taxonomy-or-category-test( $element )
+    return
+        map:merge(
+            for $lang in array:flatten( $languages )
+            return
+                map:entry( $lang, eutil:joinAndNormalize( $element/mei:desc[ @xml:lang = $lang ] ) )
+        )
+
+};
+
+(:~
+ : Returns the string content of mei:head elements in mei:taxonomy or mei:category
+ : as map, with the language codes as keys.
+ :
+ : @param $element a mei:taxonomy or mei:category element
+ :)
+declare function taxonomy:get-heads( $element as element( * ), $languages as array( * ) )
+as map( * )
+{
+    let $element :=  taxonomy:taxonomy-or-category-test( $element )
+    return
+        map:merge(
+            for $lang in array:flatten( $languages )
+            return
+                map:entry( $lang, eutil:joinAndNormalize( $element/mei:head[ @xml:lang = $lang ] ) )
+        )
+
+};
+
+(:~
+ : Returns labels of a mei:taxonomy or mei:category element.
+ : This is the 1-arity version.
+ : 
+ : @param $element a mei:taxonomy or mei:category element
+ : 
+ : @return map(*) with language codes as keys
+ :)
+declare function taxonomy:get-labels( $element as element( * ) )
+as map ( * )
+{   
+    let $element :=  taxonomy:taxonomy-or-category-test( $element )
+            
+    return
+        taxonomy:get-labels( $element, array{} )
+
+};
+
+(:~
+ : Returns labels of a mei:taxonomy or mei:category element
+ :
+ : @param $element element( * ) a mei:taxonomy or mei:category element
+ : @param $languages array( * ) an array with language codes 
+ : 
+ : @return map( * ) with language codes as keys and labels as values
+ :)
+declare function taxonomy:get-labels( $element as element( * ), $languages as array( * )? )
+as map ( * )
+{   
+    
+    let $element := taxonomy:taxonomy-or-category-test( $element )
+    
+    let $languages :=
+        if ( array:size( $languages ) = 0 ) then
+            array:append( 
+                taxonomy:get-languages( $element ),
+                "und"
+            )
+        else $languages 
+            
+    return
+        map:merge(
+            for $lang at $i in array:flatten( $languages )
+            return
+                switch ( $lang )
+                    case "und" return map:entry( "und", ( ( $element/mei:label[ not (@xml:lang ) ] )[ 1 ], $element/@label )[ 1 ] )
+                    default return 
+                      map:entry( $lang, $element/mei:label[ @xml:lang = $lang ] => normalize-space() )
+        )
+
+};
+
+(:~
+ : Recurses the descendant tree of a mei:taxonomy or mei:category element
+ : and returns distinct values of @xml:lang as array.
+ :
+ : @param $element a mei:taxonomy or mei:category element
+ :)
+declare function taxonomy:get-languages( $element as element( * ) )
+as array( * )
+{
+    (: TODO what if there is no @xml:lang :)
+    let $element :=  taxonomy:taxonomy-or-category-test( $element )
+    return
+        array { distinct-values( $element/ancestor-or-self::mei:taxonomy//@xml:lang ) }
+
+};
+
+(:~
+ : Test wheter a submitted element is a mei:taxonomy or mei:category element
+ : throws err:XPTY004 type error if not.
+ :
+ : @param $element a XML element
+ :)
+declare function taxonomy:taxonomy-or-category-test( $element as element() )
+as element()
+{
+    typeswitch( $element )
+        case $a as element( mei:taxonomy )
+                 | element( mei:category )
+            return
+                $element
+        default
+            return error( xs:QName("err:XPTY0004"), "Unexpected element: expected mei:taxonomy or mei:category" )
+
+};

--- a/data/xqm/taxonomy.xqm
+++ b/data/xqm/taxonomy.xqm
@@ -192,7 +192,8 @@ as xs:string
 declare function taxonomy:get-label-localized-as-string( $element as element( mei:category ) )
 as xs:string
 {
-    let $lang := request:get-parameter( 'lang', $eutil:lang )
+    let $lang := eutil:getSetLanguage(())
+
     let $labels := taxonomy:get-labels( $element )
     return
         if ( $labels( $lang ) ) then

--- a/data/xqm/taxonomy.xqm
+++ b/data/xqm/taxonomy.xqm
@@ -155,6 +155,21 @@ as xs:string
 
 };
 
+(:~
+ : Gets the xml:id of the innermost ancestor mei:taxonomy containing the element,
+ : or falls back to the id referenced in @class if no ancestor taxonomy exists.
+ : Use this for grouping categories by their containing taxonomy in nested structures,
+ : as opposed to get-root-identifying-string which returns the outermost ancestor.
+ :
+ : @return xs:string of the retrieved identifier
+ :)
+declare function taxonomy:get-parent-taxonomy-identifying-string( $element as element( * ) )
+as xs:string
+{
+    ($element/ancestor-or-self::mei:taxonomy[1]/@xml:id, substring-after($element/@class, '#'))[1] => xs:string()
+
+};
+
 declare function taxonomy:get-label-localized-as-string( $element as element( mei:category ) )
 as xs:string
 {

--- a/data/xqm/taxonomy.xqm
+++ b/data/xqm/taxonomy.xqm
@@ -5,7 +5,7 @@ xquery version "3.1";
  :)
 
 (:~
- : This module provides library functions for handlin MEI taxonomies
+ : This module provides library functions for handling MEI taxonomies.
  :
  : @author Benjamin W. Bohl <b.w.bohl@gmail.com>
  :)
@@ -30,19 +30,20 @@ declare namespace request = "http://exist-db.org/xquery/request";
 (: FUNCTION DECLARATIONS =================================================== :)
 
 (:~
- : Returns metadata about an mei:taxonomy
- : 
- : @param $element Anmei:taxonomy or mei:category element
+ : Returns metadata about an mei:taxonomy or mei:category element.
+ :
+ : @param $element An mei:taxonomy or mei:category element.
+ : @return map(*) containing metadata such as categories, descriptions, heads, id, label, and languages.
  :)
 declare function taxonomy:get-metadata( $element as element( * ) )
 as map( * )
 {
     let $element :=  taxonomy:taxonomy-or-category-test( $element )
-    
+
     let $idString := $element/@xml:id => xs:string()
-    
+
     let $languages := taxonomy:get-languages( $element )
-    
+
     return
         map {
             "categories": taxonomy:get-categories( $element ),
@@ -53,9 +54,15 @@ as map( * )
             "label":taxonomy:get-labels( $element ),
             "languages": taxonomy:get-languages( $element )
         }
-    
+
 };
 
+(:~
+ : Returns an array of metadata maps for all mei:category children of the given element.
+ :
+ : @param $element An mei:taxonomy or mei:category element.
+ : @return array(*)* Array of metadata maps for each child category.
+ :)
 declare function taxonomy:get-categories( $element as element( * ) )
 as array( * )*
 {
@@ -69,21 +76,27 @@ as array( * )*
 
 };
 
+(:~
+ : Returns metadata about a single mei:category element.
+ :
+ : @param $element An mei:category element.
+ : @return map(*) containing descriptions, id, label, languages, and taxonomy reference.
+ :)
 declare function taxonomy:get-category( $element as element( mei:category ) )
 as map( * )
 {
     let $idString := $element/@xml:id => xs:string()
-    
+
     let $languages := taxonomy:get-languages( $element )
-    
+
     return
         map {
             "descs": taxonomy:get-descs( $element, $languages ),
-(:            "i18n": eutil:getLanguageString($EDITION, $idString, (), $eutil:lang),:)
+(:            "i18n": eutil:getLanguageString($EDITION, $idString, (), $eutil:lang), :)
             "id": $idString,
             "label":taxonomy:get-labels( $element ),
             "languages": taxonomy:get-languages( $element ),
-            "taxonomy": $element/ancestor::mei:taxonomy/@xml:id => xs:string()
+            "taxonomy": ($element/ancestor::mei:taxonomy/@xml:id, substring-after($element/@class, '#'))[1] => xs:string()
         }
 
 };
@@ -93,6 +106,8 @@ as map( * )
  : as map, with the language codes as keys.
  :
  : @param $element a mei:taxonomy or mei:category element
+ : @param $languages array(*) Array of language codes.
+ : @return map(*) with language codes as keys and description strings as values.
  :)
 declare function taxonomy:get-descs( $element as element( * ), $languages as array( * ) )
 as map( * )
@@ -112,6 +127,8 @@ as map( * )
  : as map, with the language codes as keys.
  :
  : @param $element a mei:taxonomy or mei:category element
+ : @param $languages array(*) Array of language codes.
+ : @return map(*) with language codes as keys and head strings as values.
  :)
 declare function taxonomy:get-heads( $element as element( * ), $languages as array( * ) )
 as map( * )
@@ -129,50 +146,48 @@ as map( * )
 (:~
  : Returns labels of a mei:taxonomy or mei:category element.
  : This is the 1-arity version.
- : 
+ :
  : @param $element a mei:taxonomy or mei:category element
- : 
- : @return map(*) with language codes as keys
+ : @return map(*) with language codes as keys and labels as values.
  :)
 declare function taxonomy:get-labels( $element as element( * ) )
 as map ( * )
-{   
+{
     let $element :=  taxonomy:taxonomy-or-category-test( $element )
-            
+
     return
         taxonomy:get-labels( $element, array{} )
 
 };
 
 (:~
- : Returns labels of a mei:taxonomy or mei:category element
+ : Returns labels of a mei:taxonomy or mei:category element for given languages.
  :
- : @param $element element( * ) a mei:taxonomy or mei:category element
- : @param $languages array( * ) an array with language codes 
- : 
- : @return map( * ) with language codes as keys and labels as values
+ : @param $element a mei:taxonomy or mei:category element
+ : @param $languages array(*) an array with language codes
+ : @return map(*) with language codes as keys and labels as values.
  :)
 declare function taxonomy:get-labels( $element as element( * ), $languages as array( * )? )
 as map ( * )
-{   
-    
+{
+
     let $element := taxonomy:taxonomy-or-category-test( $element )
-    
+
     let $languages :=
         if ( array:size( $languages ) = 0 ) then
-            array:append( 
+            array:append(
                 taxonomy:get-languages( $element ),
                 "und"
             )
-        else $languages 
-            
+        else $languages
+
     return
         map:merge(
             for $lang at $i in array:flatten( $languages )
             return
                 switch ( $lang )
                     case "und" return map:entry( "und", ( ( $element/mei:label[ not (@xml:lang ) ] )[ 1 ], $element/@label )[ 1 ] )
-                    default return 
+                    default return
                       map:entry( $lang, $element/mei:label[ @xml:lang = $lang ] => normalize-space() )
         )
 
@@ -183,6 +198,7 @@ as map ( * )
  : and returns distinct values of @xml:lang as array.
  :
  : @param $element a mei:taxonomy or mei:category element
+ : @return array(*) Array of distinct language codes.
  :)
 declare function taxonomy:get-languages( $element as element( * ) )
 as array( * )
@@ -195,10 +211,12 @@ as array( * )
 };
 
 (:~
- : Test wheter a submitted element is a mei:taxonomy or mei:category element
- : throws err:XPTY004 type error if not.
+ : Tests whether a submitted element is a mei:taxonomy or mei:category element.
+ : Throws err:XPTY0004 type error if not.
  :
  : @param $element a XML element
+ : @return The input element if it is a mei:taxonomy or mei:category.
+ : @error err:XPTY0004 if the element is not of the expected type.
  :)
 declare function taxonomy:taxonomy-or-category-test( $element as element() )
 as element()

--- a/data/xqm/taxonomy.xqm
+++ b/data/xqm/taxonomy.xqm
@@ -151,7 +151,7 @@ as map( * )
 declare function taxonomy:get-root-identifying-string( $element as element ( * ) )
 as xs:string
 { (:TODO should precendence be as is or class over xml:id? :)
-    ($element/ancestor-or-self::mei:taxonomy/@xml:id, substring-after($element/@class, '#'))[1] => xs:string()
+    ($element/ancestor-or-self::mei:taxonomy[last()]/@xml:id, substring-after($element/@class, '#'))[1] => xs:string()
 
 };
 

--- a/data/xqm/taxonomy.xqm
+++ b/data/xqm/taxonomy.xqm
@@ -195,17 +195,18 @@ as xs:string
  : 2. mei:label without @xml:lang (language-neutral)
  : 3. @xml:id of the element as last resort
  :
- : @param $element a mei:taxonomy or mei:category element
- : @return xs:string — never empty if the element has @xml:id
+ : @param $element a mei:taxonomy or mei:category element, or empty sequence
+ : @return xs:string? — empty if $element is absent or has no @xml:id and no labels
  :)
-declare function taxonomy:get-label-localized-as-string( $element as element( * ) )
-as xs:string
+declare function taxonomy:get-label-localized-as-string( $element as element( * )? )
+as xs:string?
 {
-    let $lang := eutil:getSetLanguage(())
-
-    let $labels := taxonomy:get-labels( $element )
-    return
-        ($labels($lang)[. != ''], $labels('und')[. != ''], xs:string($element/@xml:id))[1]
+    if (empty($element)) then ()
+    else
+        let $lang := eutil:getSetLanguage(())
+        let $labels := taxonomy:get-labels( $element )
+        return
+            ($labels($lang)[. != ''], $labels('und')[. != ''], xs:string($element/@xml:id)[. != ''])[1]
 
 };
 

--- a/data/xqm/taxonomy.xqm
+++ b/data/xqm/taxonomy.xqm
@@ -144,29 +144,48 @@ as map( * )
 };
 
 (:~
- : Gets either the xml:id of the ancestor mei:taxonomy or the id referenced in @class
+: Returns a string identifier for grouping a category with its siblings.
  :
- : @return xs:string of the retrieved identifer
+ : Resolution order:
+ : 1. @class fragment — but only when it references an actual element in the document
+ :    (e.g. edirom-style container categories <category xml:id="ediromPriority"/>).
+ :    A @class value that has no corresponding element (e.g. bazga.annotation.class)
+ :    is skipped so it does not collapse all sub-groups into one.
+ : 2. The xml:id of the top-level ancestor mei:category that is a direct child of
+ :    the nearest ancestor mei:taxonomy.  This splits flat single-taxonomy structures
+ :    (e.g. BAZ-GA) into per-top-level-category groups.
+ : 3. The xml:id of the nearest ancestor mei:taxonomy itself as a last fallback.
+ :
+ : @return xs:string of the retrieved identifier
  :)
 declare function taxonomy:get-root-identifying-string( $element as element ( * ) )
 as xs:string
-{ (:TODO should precendence be as is or class over xml:id? :)
-    ($element/ancestor-or-self::mei:taxonomy[last()]/@xml:id, substring-after($element/@class, '#'))[1] => xs:string()
-
+{
+    let $classId       := substring-after($element/@class, '#')
+    let $nearestTaxonomy := $element/ancestor-or-self::mei:taxonomy[1]
+    let $topCategory   := ($element/ancestor-or-self::mei:category[parent::mei:taxonomy is $nearestTaxonomy])[1]
+    return (
+        $classId[. != '' and exists($element/root()/id($classId))],
+        $topCategory/@xml:id,
+        $nearestTaxonomy/@xml:id
+    )[. != ''][1] => xs:string()
 };
 
 (:~
- : Gets the xml:id of the innermost ancestor mei:taxonomy containing the element,
- : or falls back to the id referenced in @class if no ancestor taxonomy exists.
- : Use this for grouping categories by their containing taxonomy in nested structures,
- : as opposed to get-root-identifying-string which returns the outermost ancestor.
+ : Returns a string identifier for grouping a category with its siblings.
+ :
+ : Resolution order:
+ : 1. @class fragment — use when it references the grouping parent category
+ :    (e.g. edirom-style: class="#ediromPriority"; bazga-style: class="#bazga.annotation.class.editorial-intervention").
+ : 2. The xml:id of the nearest ancestor mei:taxonomy as a fallback for
+ :    categories that carry no @class.
  :
  : @return xs:string of the retrieved identifier
  :)
 declare function taxonomy:get-parent-taxonomy-identifying-string( $element as element( * ) )
 as xs:string
 {
-    ($element/ancestor-or-self::mei:taxonomy[1]/@xml:id, substring-after($element/@class, '#'))[1] => xs:string()
+    (substring-after($element/@class, '#'), $element/ancestor-or-self::mei:taxonomy[last()]/@xml:id)[. != ''][1] => xs:string()
 
 };
 

--- a/testing/XQSuite/annotation-tests.xqm
+++ b/testing/XQSuite/annotation-tests.xqm
@@ -1,0 +1,69 @@
+xquery version "3.1";
+
+(:~
+ : XQSuite unit tests for the annotation module (data/xqm/annotation.xqm).
+ :
+ : Scope: the pure / structural functions that can be exercised with in-memory
+ : constructed MEI. The reference-resolving functions (toJSON, getPriority /
+ : getPriorityLabel via eutil:get-referenced-element, get-referenced-category-elements,
+ : get-referenced-categories-as-taxonomy-array) depend on id()/doc() resolution and
+ : require stored fixtures; they are covered separately.
+ :)
+module namespace ann = "http://www.edirom.de/xquery/xqsuite/annotation-tests";
+
+import module namespace annotation = "http://www.edirom.de/xquery/annotation" at "xmldb:exist:///db/apps/Edirom-Online-Backend/data/xqm/annotation.xqm";
+
+declare namespace mei = "http://www.music-encoding.org/ns/mei";
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+
+(: annotation:get-class-idrefs-as-sequence =============================== :)
+
+(:~ @class tokens are returned as IDREFs with the leading '#' stripped. :)
+declare
+    %test:assertEquals("ediromAnnotPrio3 wega.annotation.category.articulation")
+function ann:class-idrefs() as xs:string {
+    let $a := <mei:annot xml:id="a1" type="editorialComment"
+                  class="#ediromAnnotPrio3 #wega.annotation.category.articulation"/>
+    return string-join(annotation:get-class-idrefs-as-sequence($a), " ")
+};
+
+(:~ An annotation without @class yields the empty sequence (no IDREF cast error). :)
+declare
+    %test:assertEmpty
+function ann:class-idrefs-empty() {
+    annotation:get-class-idrefs-as-sequence(<mei:annot xml:id="a1" type="editorialComment"/>)
+};
+
+
+(: annotation:getParticipants ============================================ :)
+
+(:~ Distinct document parts of the @plist tokens (the '#fragment' is dropped). :)
+declare
+    %test:assertEquals("a.xml b.xml")
+function ann:participants() as xs:string {
+    let $a := <mei:annot xml:id="a1" type="editorialComment"
+                  plist="a.xml#m1 a.xml#m2 b.xml#m1"/>
+    return string-join(annotation:getParticipants($a), " ")
+};
+
+
+(: annotation:get-category-label-localized =============================== :)
+
+(:~ A mei:category with no label resolves to its own @xml:id.
+   (The category is wrapped in a taxonomy, as it always is in real data — a category
+   with no taxonomy ancestor cannot yield a grouping identifier and would, correctly,
+   trip the as-xs:string contract of taxonomy:get-parent-taxonomy-identifying-string.) :)
+declare
+    %test:assertEquals("myCat")
+function ann:category-label-falls-to-xmlid() as xs:string {
+    let $t := <mei:taxonomy xml:id="t"><mei:category xml:id="myCat"/></mei:taxonomy>
+    return annotation:get-category-label-localized($t//mei:category)
+};
+
+(:~ An element that is neither category nor term falls back to its local name. :)
+declare
+    %test:assertEquals("rend")
+function ann:category-label-default() as xs:string {
+    annotation:get-category-label-localized(<mei:rend/>)
+};

--- a/testing/XQSuite/taxonomy-tests.xqm
+++ b/testing/XQSuite/taxonomy-tests.xqm
@@ -1,0 +1,150 @@
+xquery version "3.1";
+
+(:~
+ : XQSuite unit tests for the taxonomy module (data/xqm/taxonomy.xqm).
+ :
+ : Scope: the structural / pure functions that do not depend on id() resolution or a
+ : request context, so they can be exercised with in-memory constructed MEI. Functions
+ : that rely on id() (taxonomy:get-root-identifying-string) or doc()/base-uri
+ : (the cross-file resolvers) require stored fixtures and are covered separately.
+ :)
+module namespace tax = "http://www.edirom.de/xquery/xqsuite/taxonomy-tests";
+
+import module namespace taxonomy = "http://www.edirom.de/xquery/taxonomy" at "xmldb:exist:///db/apps/Edirom-Online-Backend/data/xqm/taxonomy.xqm";
+
+declare namespace mei = "http://www.music-encoding.org/ns/mei";
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+
+(: FIXTURES =============================================================== :)
+
+(:~ Pattern A: inner taxonomy carries its own @xml:id; categories have no @class. :)
+declare %private function tax:patternA() as element(mei:taxonomy) {
+    <mei:taxonomy xml:id="myAnnotationTypes">
+        <mei:label xml:lang="de">Annotationstypen</mei:label>
+        <mei:label xml:lang="en">Annotation Types</mei:label>
+        <mei:category xml:id="myType.structural">
+            <mei:label xml:lang="de">Strukturell</mei:label>
+            <mei:label xml:lang="en">Structural</mei:label>
+        </mei:category>
+    </mei:taxonomy>
+};
+
+(:~ Pattern B: categories name their group via @class, which takes precedence over the
+   inner taxonomy's own @xml:id. :)
+declare %private function tax:patternB() as element(mei:taxonomy) {
+    <mei:taxonomy xml:id="ediromClassification">
+        <mei:category xml:id="ediromPriority"/>
+        <mei:taxonomy xml:id="ediromPriorityTaxonomy">
+            <mei:category class="#ediromPriority" xml:id="ediromAnnotPrio1">
+                <mei:label xml:lang="de">1</mei:label>
+                <mei:label xml:lang="en">1</mei:label>
+            </mei:category>
+        </mei:taxonomy>
+    </mei:taxonomy>
+};
+
+
+(: taxonomy:get-parent-taxonomy-identifying-string ======================== :)
+
+(:~ Pattern B: the @class fragment is the grouping key. :)
+declare
+    %test:assertEquals("ediromPriority")
+function tax:parent-id-from-class() as xs:string {
+    taxonomy:get-parent-taxonomy-identifying-string(
+        tax:patternB()//mei:category[@xml:id = "ediromAnnotPrio1"])
+};
+
+(:~ Pattern A: with no @class, the grouping key is the nearest taxonomy @xml:id. :)
+declare
+    %test:assertEquals("myAnnotationTypes")
+function tax:parent-id-from-taxonomy() as xs:string {
+    taxonomy:get-parent-taxonomy-identifying-string(
+        tax:patternA()//mei:category[@xml:id = "myType.structural"])
+};
+
+
+(: taxonomy:get-languages ================================================= :)
+
+(:~ Distinct @xml:lang values found beneath the ancestor taxonomy (order-independent). :)
+declare
+    %test:assertEquals("de en")
+function tax:languages() as xs:string {
+    string-join(sort(array:flatten(taxonomy:get-languages(tax:patternA()))), " ")
+};
+
+(:~ No @xml:lang anywhere yields an empty language array. :)
+declare
+    %test:assertEquals(0)
+function tax:languages-empty() as xs:integer {
+    array:size(taxonomy:get-languages(<mei:taxonomy xml:id="t"><mei:category xml:id="c"/></mei:taxonomy>))
+};
+
+
+(: taxonomy:get-labels ==================================================== :)
+
+(:~ 2-arity, explicit language: returns the matching mei:label. :)
+declare
+    %test:assertEquals("Structural")
+function tax:labels-explicit-lang() as xs:string {
+    taxonomy:get-labels(tax:patternA()//mei:category[@xml:id = "myType.structural"], ["en"])("en")
+};
+
+(:~ 1-arity 'und' fallback: prefers @label when no language-neutral mei:label is present. :)
+declare
+    %test:assertEquals("LBL")
+function tax:labels-und-uses-label-attr() as xs:string {
+    let $t := <mei:taxonomy xml:id="t"><mei:category xml:id="c" label="LBL"><mei:label xml:lang="en">E</mei:label></mei:category></mei:taxonomy>
+    return taxonomy:get-labels($t//mei:category)("und")
+};
+
+(:~ 1-arity 'und' fallback: drops through to @xml:id when there is no label at all. :)
+declare
+    %test:assertEquals("c")
+function tax:labels-und-falls-to-xmlid() as xs:string {
+    let $t := <mei:taxonomy xml:id="t"><mei:category xml:id="c"/></mei:taxonomy>
+    return taxonomy:get-labels($t//mei:category)("und")
+};
+
+
+(: taxonomy:get-label-localized-as-string ================================= :)
+
+(:~ With no language-specific label, resolution drops to the element's @xml:id
+   regardless of the active language. :)
+declare
+    %test:assertEquals("c")
+function tax:label-localized-falls-to-xmlid() as xs:string {
+    let $t := <mei:taxonomy xml:id="t"><mei:category xml:id="c"/></mei:taxonomy>
+    return taxonomy:get-label-localized-as-string($t//mei:category)
+};
+
+(:~ An empty input yields the empty sequence. :)
+declare
+    %test:assertEmpty
+function tax:label-localized-empty() {
+    taxonomy:get-label-localized-as-string(())
+};
+
+
+(: taxonomy:taxonomy-or-category-test ===================================== :)
+
+(:~ A mei:taxonomy passes the type test and is returned unchanged. :)
+declare
+    %test:assertEquals("taxonomy")
+function tax:type-test-accepts-taxonomy() as xs:string {
+    local-name(taxonomy:taxonomy-or-category-test(<mei:taxonomy xml:id="t"/>))
+};
+
+(:~ A mei:category passes the type test and is returned unchanged. :)
+declare
+    %test:assertEquals("category")
+function tax:type-test-accepts-category() as xs:string {
+    local-name(taxonomy:taxonomy-or-category-test(<mei:category/>))
+};
+
+(:~ Any other element raises the standard XPTY0004 type error. :)
+declare
+    %test:assertError("XPTY0004")
+function tax:type-test-rejects-other() {
+    taxonomy:taxonomy-or-category-test(<mei:label/>)
+};

--- a/tests/XQSuite/run-unit-tests.xq
+++ b/tests/XQSuite/run-unit-tests.xq
@@ -11,10 +11,13 @@ import module namespace test="http://exist-db.org/xquery/xqsuite" at "resource:o
 import module namespace eut="http://www.edirom.de/xquery/xqsuite/eutil-tests" at "eutil-tests.xqm";
 import module namespace edt="http://www.edirom.de/xquery/xqsuite/edition-tests" at "edition-tests.xqm";
 import module namespace ddt="http://www.edirom.de/xquery/xqsuite/dts-document-tests" at "dts-document-tests.xqm";
+import module namespace tax="http://www.edirom.de/xquery/xqsuite/taxonomy-tests" at "taxonomy-tests.xqm";
 
 (: the test:suite() function will run all the test-annotated functions in the module whose namespace URI you provide :)
 test:suite((
     util:list-functions("http://www.edirom.de/xquery/xqsuite/eutil-tests"),
     util:list-functions("http://www.edirom.de/xquery/xqsuite/edition-tests"),
     util:list-functions("http://www.edirom.de/xquery/xqsuite/dts-document-tests")
+    util:list-functions("http://www.edirom.de/xquery/xqsuite/edition-tests"),
+    util:list-functions("http://www.edirom.de/xquery/xqsuite/taxonomy-tests"),
 ))

--- a/tests/XQSuite/run-unit-tests.xq
+++ b/tests/XQSuite/run-unit-tests.xq
@@ -12,6 +12,7 @@ import module namespace eut="http://www.edirom.de/xquery/xqsuite/eutil-tests" at
 import module namespace edt="http://www.edirom.de/xquery/xqsuite/edition-tests" at "edition-tests.xqm";
 import module namespace ddt="http://www.edirom.de/xquery/xqsuite/dts-document-tests" at "dts-document-tests.xqm";
 import module namespace tax="http://www.edirom.de/xquery/xqsuite/taxonomy-tests" at "taxonomy-tests.xqm";
+import module namespace ann="http://www.edirom.de/xquery/xqsuite/annotation-tests" at "annotation-tests.xqm";
 
 (: the test:suite() function will run all the test-annotated functions in the module whose namespace URI you provide :)
 test:suite((
@@ -20,4 +21,5 @@ test:suite((
     util:list-functions("http://www.edirom.de/xquery/xqsuite/dts-document-tests")
     util:list-functions("http://www.edirom.de/xquery/xqsuite/edition-tests"),
     util:list-functions("http://www.edirom.de/xquery/xqsuite/taxonomy-tests"),
+    util:list-functions("http://www.edirom.de/xquery/xqsuite/annotation-tests")
 ))


### PR DESCRIPTION
## Description, Context and related Issue
Add support for dynamic mei:taxonomy usage in mei annot

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs https://github.com/Edirom/Edirom-Online-Backend/issues/81

## How Has This Been Tested?
* Klarinettenquintett dataset
* BAZ-GA dataset

## Types of changes
- New feature (non-breaking change which adds functionality)
- Documentation Update
- Improvement
- Refactoring

## Overview
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Backend/blob/develop/CONTRIBUTING.md) document.

## TODOs

- [x] maintain API 1.0.0 compatibility
- [x] support old model of associating mei:annots with categories and priorities 
