### PR TITLE
Missing langDoc variable declared

### DIFF
--- a/data/xqm/eutil.xqm
+++ b/data/xqm/eutil.xqm
@@ -29,6 +29,8 @@ declare namespace util="http://exist-db.org/xquery/util";
 (: VARIABLE DECLARATIONS =================================================== :)
 
 declare variable $eutil:default-prefs-location as xs:string := '../prefs/edirom-prefs.xml';
+declare variable $eutil:lang as xs:string := eutil:getLanguage();
+declare variable $eutil:langDoc as document-node() := doc('../locale/edirom-lang-' || $eutil:lang || '.xml');
 
 (: FUNCTION DECLARATIONS =================================================== :)
 


### PR DESCRIPTION
## Description, Context and related Issue
Added the eutil:langDoc variable

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs https://github.com/Edirom/Edirom-Online/issues/86

## How Has This Been Tested?
Edition Example on my machine

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Overview
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Backend/blob/develop/CONTRIBUTING.md) document.
- All new and existing tests passed.
