### PR TITLE
changed test for language completeness

### DIFF
--- a/data/xqm/edition.xqm
+++ b/data/xqm/edition.xqm
@@ -123,8 +123,8 @@ declare function edition:getLanguageCodesSorted($uri as xs:string) as xs:string*
         (
             $languages[@complete eq 'true']/@xml:lang ,
             $languages[exists(@complete) and not(@complete eq 'true' or @complete eq 'false')]/@xml:lang ,
-            $languages[@complete eq 'false']/@xml:lang ,
-            $languages[not(@complete)]/@xml:lang
+            $languages[not(@complete)]/@xml:lang ,
+            $languages[@complete eq 'false']/@xml:lang 
         )[. ne ""]
 };
 


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
Changed the test for language completeness to only check for string values (true, false) and sort order:
1. `@complete='true'`
2. `@complete eq something else`
3. `@complete not present`
4. `@complete='false'`

output order: de, es, fr, en

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Fixes #4 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
For EditionExample added part in edirom-edition-example.xml

`<languages>
        <language xml:lang="es" complete="bla"/>
        <language xml:lang="fr"/>
        <language xml:lang="en" complete="false"/>
        <language xml:lang="de" complete="true"/>
    </languages>`

Result on http://localhost:8089/

<img width="535" height="621" alt="image" src="https://github.com/user-attachments/assets/645e0bb4-a9be-46f0-9bed-272e4113a02c" />

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)
- Improvement

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Backend/blob/develop/CONTRIBUTING.md) document.
- All new and existing tests passed.
