### PR TITLE
Fix 72 goto measure function not working properly

### DIFF
--- a/data/xql/getMeasures.xql
+++ b/data/xql/getMeasures.xql
@@ -82,7 +82,7 @@ declare function local:get-score-measures($measures as element(mei:measure)*) as
     return
         map {
             "id": $measure/string(@xml:id),
-            "voice": "voice"
+            "voice": "score"
         }
 };
 
@@ -101,7 +101,7 @@ declare function local:getMeasures($mdiv as element(mei:mdiv)?, $mdivID as xs:st
             if($hasParts)
             then local:get-part-measures($measure)
             else local:get-score-measures($measure)
-        order by eutil:sort-as-numeric-alpha($measureN)
+        order by eutil:compute-measure-sort-key($measureN)
         return
             map {
                 "id": 'measure_' || $mdivID || '_' || $measureN,

--- a/data/xql/getMeasures.xql
+++ b/data/xql/getMeasures.xql
@@ -106,7 +106,7 @@ declare function local:getMeasures($mdiv as element(mei:mdiv)?, $mdivID as xs:st
             map {
                 "id": 'measure_' || $mdivID || '_' || $measureN,
                 "measures": array { $measures },
-                "mdivs": $mdivID,
+                "mdivs": array { $mdivID },
                 "name": $measureN
             }
     }

--- a/data/xql/getMeasures.xql
+++ b/data/xql/getMeasures.xql
@@ -104,7 +104,7 @@ declare function local:getMeasures($mdiv as element(mei:mdiv)?, $mdivID as xs:st
         order by eutil:compute-measure-sort-key($measureN)
         return
             map {
-                "id": 'measure_' || $mdivID || '_' || $measureN,
+                "id": (if (count($measures) eq 1) then (map:get($measures[1], 'id')) else ('measure_' || $mdivID || '_' || $measureN) ),
                 "measures": array { $measures },
                 "mdivs": array { $mdivID },
                 "name": $measureN
@@ -139,3 +139,4 @@ let $hasParts := exists($mdiv//mei:part)
 
 return
     local:getMeasures($mdiv, $mdivID, $hasParts)
+ 

--- a/data/xqm/eutil.xqm
+++ b/data/xqm/eutil.xqm
@@ -335,6 +335,26 @@ declare function eutil:sort-as-numeric-alpha($seq as item()* )  as item()* {
 
 } ;
 
+
+(:~
+ : Computes a sort key for numeric-alpha values or nodes (e.g. 1, 1a, 1b, 2)
+ :
+ : @see     http://www.xqueryfunctions.com/xq/functx_compute-sort-key.html
+ : @param   $key the key to compute the sort key for
+ : @return  the computed sort key
+ :)
+declare function eutil:compute-measure-sort-key( $key as xs:string ) as xs:string {
+    
+    let $itemPart1 := (functx:get-matches($key, '\d+'))[1]
+    (: let $itemPart2 := substring-after($key, $itemPart1) :)
+    let $keylength := string-length($itemPart1)
+    let $prefix := functx:repeat-string('0', 30 - $keylength)
+
+    return concat($prefix, $key)
+    
+};
+
+
 (:~
  : Extracts an ISO 639 language code from a given ISO 3166-1 language code
  :

--- a/data/xqm/eutil.xqm
+++ b/data/xqm/eutil.xqm
@@ -346,7 +346,6 @@ declare function eutil:sort-as-numeric-alpha($seq as item()* )  as item()* {
 declare function eutil:compute-measure-sort-key( $key as xs:string ) as xs:string {
     
     let $itemPart1 := (functx:get-matches($key, '\d+'))[1]
-    (: let $itemPart2 := substring-after($key, $itemPart1) :)
     let $keylength := string-length($itemPart1)
     let $prefix := functx:repeat-string('0', 30 - $keylength)
 

--- a/testing/XQSuite/eutil-tests.xqm
+++ b/testing/XQSuite/eutil-tests.xqm
@@ -121,3 +121,30 @@ declare
     function eut:test-getLanguageString-4-arity($langFileURI as xs:string, $key as xs:string, $values as xs:string*, $lang as xs:string) as xs:string? {
         eutil:getLanguageString($langFileURI, $key, $values, $lang)
 };
+
+declare
+    %test:args("1", "2")     %test:assertFalse
+    %test:args("2", "1")     %test:assertTrue
+    %test:args("2", "2")     %test:assertFalse
+    %test:args("1a", "2b")     %test:assertFalse
+    %test:args("10a", "2b")     %test:assertTrue
+    %test:args("10a", "2ba")     %test:assertTrue
+    %test:args("10a1", "10ba")     %test:assertFalse
+    %test:args("2b", "1a")     %test:assertTrue
+    %test:args("", "2")     %test:assertFalse
+    %test:args("2", "")     %test:assertTrue
+    function eut:test-compute-measure-sort-key($key1 as xs:string, $key2 as xs:string) as xs:boolean {
+        eutil:compute-measure-sort-key($key1) > eutil:compute-measure-sort-key($key2)
+};
+
+declare
+    %test:arg("seq", 2, 1, 3)     %test:assertEquals(1, 2, 3)
+    %test:arg("seq", 1, 2, 3)     %test:assertEquals(1, 2, 3)
+    %test:arg("seq", "1", "2", "3")     %test:assertEquals("1", "2", "3")
+    %test:arg("seq", "1a", "1", "10", "2", "10b", "3s")     %test:assertEquals("1", "1a", "2", "3s", "10", "10b")
+    %test:arg("seq", "10aa", "10aaa", "10x", "2c", "10_b")     %test:assertEquals("2c", "10_b", "10aa", "10aaa", "10x")
+    %test:arg("seq", "<a/>", "<c/>", "<b/>")     %test:assertEquals("<a/>", "<c/>", "<b/>")
+    %test:arg("seq", "<a>1</a>", "<c>3</c>", "<b>2</b>")     %test:assertEquals("<a>1</a>", "<b>2</b>", "<c>3</c>")
+    function eut:sort-as-numeric-alpha($seq as item()*) as item()* {
+        eutil:sort-as-numeric-alpha($seq)
+};


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
This PR fixes issue #72 by remedying bugs introduced in 2048f74a76dd2f978e6490837899062d7bd01a0d.
Additionally, a new function `eutil:compute-measure-sort-key` is introduced (along with tests), derived from `eutil:sort-as-numeric-alpha` for sorting measure labels like "11a" and "100" appropriately.

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs https://github.com/Edirom/Edirom-Online/issues/72

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
Tested with the clarinet quintet data.

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)
- Improvement
- Refactoring

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Backend/blob/develop/CONTRIBUTING.md) document.
- I have added tests to cover my changes at [testing](https://github.com/Edirom/Edirom-Online-Backend/tree/develop/testing)

