### PR TITLE
measure translations; annotation translations; buttons extended

### DIFF
--- a/data/locale/edirom-lang-de.xml
+++ b/data/locale/edirom-lang-de.xml
@@ -56,8 +56,10 @@
         <entry key="view.desktop.Desktop_Tile" value="Nebeneinander"/>
         
         <entry key="view.desktop.TaskBar_concordanceNav" value="Öffne Konkordanznavigator"/>
-        <entry key="view.desktop.TaskBar_measureNumbers" value="Taktzahlen einblenden"/>
-        <entry key="view.desktop.TaskBar_annotations" value="Anmerkungen einblenden"/>
+        <entry key="view.desktop.TaskBar_measureNumbers" value="Taktzahlen ein-/ausblenden"/>
+        <entry key="view.desktop.TaskBar_showMeasures" value="Taktzahlen ein-/ausblenden (global)"/>
+        <entry key="view.desktop.TaskBar_annotations" value="Anmerkungen ein-/ausblenden"/>
+        <entry key="view.desktop.TaskBar_showAnnotations" value="Anmerkungen ein-/ausblenden (global)"/>
         <entry key="view.desktop.TaskBar_help" value="Hilfe"/>
         <entry key="view.desktop.TaskBar_pref" value="Einstellungen"/>
         <entry key="view.desktop.TaskBar_lang" value="Sprache umschalten"/>
@@ -106,10 +108,10 @@
         <entry key="view.window.source.SourceView_prioMenu" value="Prioritäten…"/>
         <entry key="view.window.source.SourceView_gotoMovement" value="Gehe zu Satz/Nummer…"/>
         <entry key="view.window.source.SourceView_layersMenu" value="Ebenen…"/>
-        <entry key="view.window.source.SourceView_showMeasures" value="Taktzählung ein-/ausblenden"/>
+        <entry key="view.window.source.SourceView_showMeasures" value="Taktzählung ein-/ausblenden (in diesem Fenster)"/>
         <entry key="view.window.source.SourceView_fitView" value="Ansicht einpassen"/>
         <entry key="view.window.source.SourceView_annotationsMenu" value="Anmerkungen"/>
-        <entry key="view.window.source.SourceView_ShowAnnotations" value="Anmerkungen ein-/ausblenden"/>
+        <entry key="view.window.source.SourceView_showAnnotations" value="Anmerkungen ein-/ausblenden (in diesem Fenster)"/>
         <entry key="view.window.source.SourceView_gotoMenu" value="Gehe zu…"/>
         <entry key="view.window.source.SourceView_gotoMeasure" value="Gehe zu Takt…"/>
         <entry key="view.window.source.SourceView_GotoMsg_Title" value="Gehe zu Takt…"/>

--- a/data/locale/edirom-lang-en.xml
+++ b/data/locale/edirom-lang-en.xml
@@ -56,8 +56,10 @@
         <entry key="view.desktop.Desktop_Tile" value="Tile"/>
         
         <entry key="view.desktop.TaskBar_concordanceNav" value="Open concordance navigator"/>
-        <entry key="view.desktop.TaskBar_measureNumbers" value="Show measure numbers"/>
-        <entry key="view.desktop.TaskBar_annotations" value="Show annotations"/>
+        <entry key="view.desktop.TaskBar_measureNumbers" value="Show/hide measure numbers"/>
+        <entry key="view.desktop.TaskBar_showMeasures" value="Show/hide measure numbers (global)"/>
+        <entry key="view.desktop.TaskBar_annotations" value="Show/hide annotations"/>
+        <entry key="view.desktop.TaskBar_showAnnotations" value="Show/hide annotations (global)"/>
         <entry key="view.desktop.TaskBar_help" value="Help"/>
         <entry key="view.desktop.TaskBar_pref" value="Preferences"/>
         <entry key="view.desktop.TaskBar_lang" value="Switch language"/>
@@ -106,7 +108,7 @@
         <entry key="view.window.source.SourceView_prioMenu" value="Priorities…"/>
         <entry key="view.window.source.SourceView_gotoMovement" value="Go to movement/number…"/>
         <entry key="view.window.source.SourceView_layersMenu" value="Layers…"/>
-        <entry key="view.window.source.SourceView_showMeasures" value="Show/Hide measures"/>
+        <entry key="view.window.source.SourceView_showMeasures" value="Show/hide measures (this window)"/>
         <entry key="view.window.source.SourceView_fitView" value="Fit score"/>
         <entry key="view.window.source.SourceView_PageBasedView" value="Page based view"/>
         <entry key="view.window.source.SourceView_PageBasedView_previousPage" value="Previous page"/>
@@ -120,7 +122,7 @@
         <entry key="view.window.source.SourceView_MeasureBasedView_movementSelectorBox" value="Select movement"/>
         <entry key="view.window.source.SourceView_MeasureBasedView_selectVoices" value="Select parts"/>
         <entry key="view.window.source.SourceView_annotationsMenu" value="Annotations"/>
-        <entry key="view.window.source.SourceView_ShowAnnotations" value="Show/Hide annotations"/>
+        <entry key="view.window.source.SourceView_showAnnotations" value="Show/hide annotations (this window)"/>
         <entry key="view.window.source.SourceView_gotoMenu" value="Go to…"/>
         <entry key="view.window.source.SourceView_gotoMeasure" value="Go to measure…"/>
         <entry key="view.window.source.SourceView_GotoMsg_Title" value="Go to measure…"/>


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
New translations were needed because of buttons having been moved to new places (from top menu to bottom task bar in views)

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs https://github.com/Edirom/Edirom-Online-Frontend/issues/119

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
Building with branches of frontend and backend. 
In Edirom Online repo as long as https://github.com/Edirom/Edirom-Online/pull/624 is not merged yet:

`git checkout ftr-623-fetch-submodules-during-git-clone && export BE_BRANCH=ftr-new-icon-titles && export FE_BRANCH=ftr-119-web-component-icons && docker compose down --volumes --remove-orphans && docker compose build --no-cache && docker compose up`

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- New feature (non-breaking change which adds functionality)

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Backend/blob/develop/CONTRIBUTING.md) document.