### PR TITLE
Fix: only one blank in resolved nested language keys

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -46,7 +46,7 @@ identifiers:
     value: 10.5281/zenodo.17953690
     description: Edirom Online Backend
 repository-code: https://github.com/Edirom/Edirom-Online-Backend
-commit: 9768e77239ddd9a6c524707a0bfc0323b90b64c4
+commit: db26ce9641ec4e23eef8a58a4463da902f76758b
 abstract: >-
   Edirom-Online Backend is the backend for the Edirom 
   Online which is used for the presentation and
@@ -54,5 +54,5 @@ abstract: >-
   particularly in the fields of musicology and philology.
 license: GPL-3.0
 version: v1.2.0
-date-released: 2025-12-22
+date-released: 2026-01-05
 

--- a/data/locale/edirom-lang-de.xml
+++ b/data/locale/edirom-lang-de.xml
@@ -142,7 +142,7 @@
         <entry key="view.desktop.Desktop" value="Desktop"/>
         <entry key="view.desktop.TopBar" value="Toolbar"/>
         <entry key="view.desktop.TopBar_searchField" value="Suchfeld"/>
-        <entry key="view.desktop.TopBar_homeBtn" value="{key=view.desktop.TaskBar_home} Button"/>
+        <entry key="view.desktop.TopBar_homeBtn" value="{key=view.desktop.TaskBar_home}Button"/>
         <entry key="view.desktop.TaskBar" value="Taskbar"/>
         <entry key="view.desktop.TaskBar_btnDesktop" value="Button der Task-Leiste"/>
         <entry key="view.window.TopBar" value="Fenster-Toolbar"/>

--- a/data/locale/edirom-lang-en.xml
+++ b/data/locale/edirom-lang-en.xml
@@ -142,7 +142,7 @@
         <entry key="view.desktop.Desktop" value="Desktop"/>
         <entry key="view.desktop.TopBar" value="Toolbar"/>
         <entry key="view.desktop.TopBar_searchField" value="Search Field"/>
-        <entry key="view.desktop.TopBar_homeBtn" value="{key=view.desktop.TaskBar_home} button"/>
+        <entry key="view.desktop.TopBar_homeBtn" value="{key=view.desktop.TaskBar_home}button"/>
         <entry key="view.desktop.TaskBar" value="Taskbar"/>
         <entry key="view.desktop.TaskBar_btnDesktop" value="Taskbar"/>
         <entry key="view.window.TopBar" value="Window toolbar"/>


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
This can easily be solved by removing the single space after the nested translation in the language file/s

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs #5 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
in any edition
-> go to help (English), search for "Home" and see that third occurrence ("Home button") is followed only by a single blank

<img width="531" height="323" alt="image" src="https://github.com/user-attachments/assets/f87ddabb-dc33-492b-9322-1f486a5b33d0" />


## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Backend/blob/develop/CONTRIBUTING.md) document.