### PR TITLE
127 bug loading edirom help modifies the appearance of other texts

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -46,7 +46,7 @@ identifiers:
     value: 10.5281/zenodo.17953690
     description: Edirom Online Backend
 repository-code: https://github.com/Edirom/Edirom-Online-Backend
-commit: 17c5e1b5185618af050e6c047f6d0ba9ea690233
+commit: 5af5e8e1c102be2df684856859d4c8d3515f740b
 abstract: >-
   Edirom-Online Backend is the backend for the Edirom 
   Online which is used for the presentation and
@@ -54,5 +54,5 @@ abstract: >-
   particularly in the fields of musicology and philology.
 license: GPL-3.0
 version: v1.2.0
-date-released: 2026-01-13
+date-released: 2026-01-19
 

--- a/data/xql/getHelp.xql
+++ b/data/xql/getHelp.xql
@@ -54,10 +54,19 @@ let $doc :=
         </parameters>
     )
 
+let $xsl := doc('../xslt/edirom_removeHead.xsl')
+let $doc :=
+    transform:transform($doc, $xsl,
+        <parameters>
+
+        </parameters>
+    )
+
 return
     transform:transform($doc, doc('../xslt/edirom_idPrefix.xsl'),
         <parameters>
             <param name="idPrefix" value="{$idPrefix}"/>
         </parameters>
     )
+    
 

--- a/data/xslt/edirom_removeHead.xsl
+++ b/data/xslt/edirom_removeHead.xsl
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl" exclude-result-prefixes="xs xd" version="3.0">
+
+    <xd:doc scope="stylesheet">
+        <xd:desc>This stylesheet is intended asa sceond run on HTML content for the Edirom Online, in order to prepend any ID with a prefix and avoid invalid HTML when an object is open multiple times in one Edirom Online insatnce.</xd:desc>
+    </xd:doc>
+    
+    <xd:doc scope="component">
+        <xd:desc>The $idPrefix parameter is submitted externally and is the value prepended to IDs etc.</xd:desc>
+    </xd:doc>
+    <xsl:param name="idPrefix"/>
+    
+    <xd:doc scope="component">
+        <xd:desc>The root template</xd:desc>
+    </xd:doc>
+    <xsl:template match="/">
+        <xsl:apply-templates/>
+    </xsl:template>
+    
+    <xd:doc>
+        <xd:desc>Override the dafault template for elements to also apply templates on the attribute axis.</xd:desc>
+    </xd:doc>
+    <xsl:template match="*">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xd:doc scope="component">
+        <xd:desc>Override default template for attributes, to copy instead of printing text content.</xd:desc>
+    </xd:doc>
+    <xsl:template match="@*">
+        <xsl:copy/>
+    </xsl:template>
+    
+    <xd:doc scope="component">
+        <xd:desc>Override default templates for text comments and processing instructions to copy nodes.</xd:desc>
+    </xd:doc>
+    <xsl:template match="text() | comment() | processing-instruction()">
+        <xsl:copy/>
+    </xsl:template>
+
+
+    <xd:doc scope="component">
+        <xd:desc>Remove head elements like link, meta, title.</xd:desc>
+    </xd:doc>
+    <xsl:template match="xhtml:link | xhtml:meta | xhtml:title">
+        <!-- remove head elements -->
+        
+    </xsl:template>
+    
+</xsl:stylesheet>


### PR DESCRIPTION
## Description, Context, and Related Issue
Fix bug 127 by introducing a new XSL that removes unnecessary meta elements from the help output. These meta elements caused imported stylesheets to be applied to the entire DOM.
<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs https://github.com/Edirom/Edirom-Online-Backend/issues/127

## How Has This Been Tested?
- Klarinettenquintett dataset

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue

## Overview
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Backend/blob/develop/CONTRIBUTING.md) document.
- All new and existing tests passed.
