### PR TITLE
Add branch filter for main to update-citation workflow

### DIFF
--- a/.github/workflows/update-citation.yml
+++ b/.github/workflows/update-citation.yml
@@ -2,8 +2,13 @@ name: Update CITATION.cff metadata
 
 on:
   push:
+    branches:
+      - main
     paths-ignore:
       - CITATION.cff
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: write


### PR DESCRIPTION
This follows the discussion in https://github.com/Edirom/Edirom-Online-Frontend/issues/135
It reduces the automatic updates of the CITATION.cff to be triggered only on the main branch.
This leads to less action runs (and necessary pulls and merges) while still getting the updated infos (date and commit hash) into the software releases.