### PR TITLE
align getting and setting of the language (aka `$lang` parameter)  in the backend

### DIFF
--- a/data/xql/getAnnotation.xql
+++ b/data/xql/getAnnotation.xql
@@ -36,7 +36,7 @@ declare variable $imageserver := edition:getPreference('image_server', $edition)
 
 declare variable $imageBasePath := edition:getPreference('image_prefix', $edition);
 
-declare variable $lang := request:get-parameter('lang', '');
+declare variable $lang := eutil:getSetLanguage(());
 
 (: FUNCTION DECLARATIONS =================================================== :)
 

--- a/data/xql/getAnnotationPreviews.xql
+++ b/data/xql/getAnnotationPreviews.xql
@@ -30,7 +30,7 @@ declare option output:media-type "application/json";
 
 (: VARIABLE DECLARATIONS =================================================== :)
 
-declare variable $lang := request:get-parameter('lang', '');
+declare variable $lang := eutil:getSetLanguage(());
 declare variable $edition := request:get-parameter('edition', '');
 declare variable $imageserver := edition:getPreference('image_server', $edition);
 declare variable $uri := request:get-parameter('uri', '');

--- a/data/xql/getAnnotationText.xql
+++ b/data/xql/getAnnotationText.xql
@@ -29,7 +29,7 @@ declare option output:media-type "text/html";
 
 (: VARIABLE DECLARATIONS =================================================== :)
 
-declare variable $lang := request:get-parameter('lang', '');
+declare variable $lang := eutil:getSetLanguage(());
 
 (: QUERY BODY ============================================================== :)
 

--- a/data/xql/getConcordances.xql
+++ b/data/xql/getConcordances.xql
@@ -23,7 +23,7 @@ declare option output:media-type "application/json";
 
 (: VARIABLE DECLARATIONS =================================================== :)
 
-declare variable $lang := request:get-parameter('lang', '');
+declare variable $lang := eutil:getSetLanguage(());
 
 (: FUNCTION DECLARATIONS =================================================== :)
 

--- a/data/xql/getHeader.xql
+++ b/data/xql/getHeader.xql
@@ -34,7 +34,7 @@ let $docUri :=
     else
         ($uri)
 let $doc := eutil:getDoc($docUri)
-let $lang := request:get-parameter('lang', 'de')
+let $lang := eutil:getSetLanguage(())
 
 let $base := concat(replace(system:get-module-load-path(), 'embedded-eXist-server', ''), '/../xslt/') (: TODO: Prüfen, wie wir an dem replace vorbei kommen:)
 

--- a/data/xql/getLinkTarget.xql
+++ b/data/xql/getLinkTarget.xql
@@ -29,7 +29,7 @@ declare option output:media-type "application/json";
 
 (: VARIABLE DECLARATIONS =================================================== :)
 
-declare variable $lang := request:get-parameter('lang', '');
+declare variable $lang := eutil:getSetLanguage(());
 declare variable $uri := request:get-parameter('uri', '');
 
 (: FUNCTION DECLARATIONS =================================================== :)

--- a/data/xql/search.xql
+++ b/data/xql/search.xql
@@ -50,7 +50,7 @@ declare function local:getPath($node as node()) as xs:string {
 
 (: QUERY BODY ============================================================== :)
 
-let $lang := request:get-parameter('lang', '')
+let $lang := eutil:getSetLanguage(())
 let $edition := request:get-parameter('edition', '')
 let $term := request:get-parameter('term', '')
 

--- a/data/xqm/eutil.xqm
+++ b/data/xqm/eutil.xqm
@@ -26,6 +26,26 @@ declare namespace pref="http://www.edirom.de/ns/prefs/1.0";
 
 (: VARIABLE DECLARATIONS =================================================== :)
 
+(:
+    Determine the application root collection from the current module load path.
+:)
+declare variable $eutil:app-root as xs:string :=
+    let $rawPath := replace(system:get-module-load-path(), '/null/', '//')
+    let $modulePath :=
+        (: strip the xmldb: part :)
+        if (starts-with($rawPath, "xmldb:exist://")) then
+            if (starts-with($rawPath, "xmldb:exist://embedded-eXist-server")) then
+                substring($rawPath, 36)
+            else if (contains($rawPath, "/xmlrpc/")) then
+                substring-after($rawPath, "/xmlrpc")
+            else
+                substring($rawPath, 15)
+        else
+            $rawPath
+    return
+        substring-before($modulePath, "/data/xqm")
+;
+
 declare variable $eutil:default-prefs-location as xs:string := '../prefs/edirom-prefs.xml';
 declare variable $eutil:lang as xs:string := eutil:getLanguage();
 declare variable $eutil:langDoc as document-node() := doc('../locale/edirom-lang-' || $eutil:lang || '.xml');

--- a/data/xqm/eutil.xqm
+++ b/data/xqm/eutil.xqm
@@ -6,9 +6,6 @@ xquery version "3.1";
 (:~
  : This module provides library utility functions
  :
- : @author <a href="mailto:roewenstrunk@edirom.de">Daniel Röwenstrunk</a>
- : @author <a href="mailto:roewenstrunk@edirom.de">Nikolaos Beer</a>
- : @author <a href="mailto:bohl@edirom.de">Benjamin W. Bohl</a>
  :)
 
 module namespace eutil = "http://www.edirom.de/xquery/eutil";

--- a/data/xqm/eutil.xqm
+++ b/data/xqm/eutil.xqm
@@ -47,7 +47,7 @@ declare variable $eutil:app-root as xs:string :=
     return
         substring-before($modulePath, "/data/xqm")
 ;
-
+declare variable $eutil:INVALID_LANGUAGE_CODE := QName("http://www.edirom.de/xquery/eutil", "InvalidLanguageCodeError");
 declare variable $eutil:default-prefs-location as xs:string := '../prefs/edirom-prefs.xml';
 declare variable $eutil:supported-languages :=
     (: Extract supported languages from the provided langFiles :)
@@ -381,7 +381,7 @@ declare function eutil:getSetLanguage($lang as xs:string?) as xs:string? {
             session:set-attribute('lang', $lang)
         )
         else (
-            util:log-system-out('Language code "' || $lang || '" is not supported. Please try with "' || string-join($eutil:supported-languages, '", "') || '".')
+            error($eutil:INVALID_LANGUAGE_CODE, 'Language code "' || $lang || '" is not supported. Please try with "' || string-join($eutil:supported-languages, '", "') || '".')
         )
     else if (request:get-parameter('lang', '') = $eutil:supported-languages)
     then (

--- a/data/xqm/eutil.xqm
+++ b/data/xqm/eutil.xqm
@@ -437,7 +437,7 @@ declare function eutil:iso3166-1-to-iso639($iso3166-1 as xs:string) as xs:string
  : @author Benjamin W. Bohl
  : @return xs:string ISO 639 language code
  :)
-declare function eutil:request-lang-preferred-iso639() as xs:string {
+declare function eutil:request-lang-preferred-iso639() as xs:string? {
 
     let $request.accept-language := request:get-header("Accept-Language")
     return
@@ -460,7 +460,7 @@ declare function eutil:request-lang-preferred-iso639() as xs:string {
                 eutil:iso3166-1-to-iso639($tokens.qmax.first)
         
         else
-            "en"
+            ()
 
 };
 

--- a/data/xqm/eutil.xqm
+++ b/data/xqm/eutil.xqm
@@ -19,10 +19,12 @@ import module namespace functx = "http://www.functx.com";
 declare namespace edirom="http://www.edirom.de/ns/1.3";
 declare namespace mei="http://www.music-encoding.org/ns/mei";
 declare namespace request="http://exist-db.org/xquery/request";
+declare namespace session="http://exist-db.org/xquery/session";
 declare namespace system="http://exist-db.org/xquery/system";
 declare namespace tei="http://www.tei-c.org/ns/1.0";
 declare namespace util="http://exist-db.org/xquery/util";
 declare namespace pref="http://www.edirom.de/ns/prefs/1.0";
+declare namespace xmldb="http://exist-db.org/xquery/xmldb";
 
 (: VARIABLE DECLARATIONS =================================================== :)
 
@@ -47,8 +49,14 @@ declare variable $eutil:app-root as xs:string :=
 ;
 
 declare variable $eutil:default-prefs-location as xs:string := '../prefs/edirom-prefs.xml';
-declare variable $eutil:lang as xs:string := eutil:getLanguage();
-declare variable $eutil:langDoc as document-node() := doc('../locale/edirom-lang-' || $eutil:lang || '.xml');
+declare variable $eutil:supported-languages :=
+    (: Extract supported languages from the provided langFiles :)
+    collection($eutil:app-root || '/data/locale')//langFile/data(lang);
+declare variable $eutil:langDoc :=
+    function($lang as xs:string?) as document-node()? {
+        collection($eutil:app-root || '/data/locale')//langFile/lang[.=eutil:getSetLanguage($lang)]/root()
+        (:eutil:getDoc('../locale/edirom-lang-' || eutil:getSetLanguage($lang) || '.xml'):)
+    };
 
 (: FUNCTION DECLARATIONS =================================================== :)
 
@@ -81,7 +89,7 @@ declare function eutil:getNamespace($node as node()) as xs:string {
  :)
 declare function eutil:getLocalizedName($node as element()) as xs:string {
 
-    eutil:getLocalizedName($node, request:get-parameter('lang', ''))
+    eutil:getLocalizedName($node, eutil:getSetLanguage(()))
 
 };
 
@@ -227,7 +235,7 @@ declare function eutil:getDoc($uri as xs:string?) as document-node()? {
  :)
 declare function eutil:getPartLabel($measureOrPerfRes as node(), $type as xs:string) as xs:string {
 
-    let $lang := $eutil:lang
+    let $lang := eutil:getSetLanguage(())
 
     let $part := $measureOrPerfRes/ancestor::mei:part
     let $voiceRef := $part//mei:staffDef/@decls
@@ -267,7 +275,7 @@ declare function eutil:getPartLabel($measureOrPerfRes as node(), $type as xs:str
  :)
 declare function eutil:getLanguageString($key as xs:string, $values as xs:string*) as xs:string? {
 
-    eutil:getLanguageString($key, $values, eutil:getLanguage())
+    eutil:getLanguageString($key, $values, eutil:getSetLanguage(()))
 };
 
 (:~
@@ -282,7 +290,7 @@ declare function eutil:getLanguageString($key as xs:string, $values as xs:string
  :)
 declare function eutil:getLanguageString($key as xs:string, $values as xs:string*, $lang as xs:string) as xs:string? {
 
-    let $langString := $eutil:langDoc//entry[@key = $key]/string(@value)
+    let $langString := $eutil:langDoc($lang)//entry[@key = $key]/string(@value)
 
     return
         if($langString) 
@@ -315,7 +323,7 @@ declare function eutil:getLanguageString($langFileURI as xs:string, $key as xs:s
             $langFileCustom//entry[@key = $key]/@value => string()
         (: If not, take the value for the key in the default language file :)
         else
-            $eutil:langDoc//entry[@key = $key]/@value => string()
+            $eutil:langDoc($lang)//entry[@key = $key]/@value => string()
     return
         if($langString) 
         (: replace placeholders in the language string with values provided to the function as parameter :)
@@ -349,16 +357,47 @@ declare function eutil:getPreference($key as xs:string, $preferencesURI as xs:st
 };
 
 (:~
- : Return the application language
+ : Get and set the application language
  :
+ : If a `$lang` parameter is provided and it is supported by some langFile, the same value will be returned
+ :      and saved to the current session. If the provided value is not supported, an error will be raised.
+ : If no `$lang` parameter is provided (i.e. `$lang` equals the empty-sequence), the function will try
+ :      to determine the language in the following order:
+ : 1. from the HTTP request parameter "lang"
+ : 2. from the session attribute "lang"
+ : 3. from the preferred browser language as provided in the "Accept-Language" header
+ : 4. from the first supported language provided by `$eutil:supported-languages`
+ :
+ : @param $lang The language code (e.g. "de" or "en")
  : @return The language key
  :)
-declare function eutil:getLanguage() as xs:string {
-    
-    if (request:get-parameter("lang", "") != "") then
-        request:get-parameter("lang", "")
-    else    
-        'de'
+declare function eutil:getSetLanguage($lang as xs:string?) as xs:string? {
+
+    if ($lang)
+    then
+        if ($lang = $eutil:supported-languages)
+        then (
+            $lang,
+            session:set-attribute('lang', $lang)
+        )
+        else (
+            util:log-system-out('Language code "' || $lang || '" is not supported. Please try with "' || string-join($eutil:supported-languages, '", "') || '".')
+        )
+    else if (request:get-parameter('lang', '') = $eutil:supported-languages)
+    then (
+        request:get-parameter('lang', ''),
+        session:set-attribute('lang', request:get-parameter('lang', ''))
+    )
+    else if(session:exists() and session:get-attribute('lang') = $eutil:supported-languages)
+    then
+        session:get-attribute('lang')
+    else if(eutil:request-lang-preferred-iso639() = $eutil:supported-languages)
+    then (
+        eutil:request-lang-preferred-iso639(),
+        session:set-attribute('lang', eutil:request-lang-preferred-iso639())
+    )
+    else
+        $eutil:supported-languages[1]
 };
 
 (:~

--- a/testing/XQSuite/edition-tests.xqm
+++ b/testing/XQSuite/edition-tests.xqm
@@ -10,7 +10,7 @@ declare namespace test="http://exist-db.org/xquery/xqsuite";
 declare
     (: check xml:id :)
     %test:args("xqsuite_test_edition")
-    %test:assertEquals("xmldb:exist:///db/apps/Edirom-Online/testing/XQSuite/data/edition.xml")
+    %test:assertEquals("xmldb:exist:///db/apps/Edirom-Online-Backend/testing/XQSuite/data/edition.xml")
     (: check database path :)
     %test:args("/db/apps/Edirom-Online-Backend/testing/XQSuite/data/edition.xml")
     %test:assertEquals("xmldb:exist:///db/apps/Edirom-Online-Backend/testing/XQSuite/data/edition.xml")

--- a/testing/XQSuite/eutil-tests.xqm
+++ b/testing/XQSuite/eutil-tests.xqm
@@ -71,11 +71,11 @@ declare
     (: Test replacements with existing key without placeholders :)
     %test:args("view.desktop.Desktop_Maximize", "foo", "de") %test:assertEquals("Maximieren")
     (: Test replacements with existing key and non-existing language :)
-    %test:args("view.desktop.Desktop_Maximize", "foo", "foo1g4#lang") %test:assertEmpty
+    %test:args("view.desktop.Desktop_Maximize", "foo", "foo1g4#lang") %test:assertError("eutil:InvalidLanguageCodeError")
     (: Test empty replacements with non-existing key and non-existing language :)
     %test:arg("key", "foo1g4#")
     %test:arg("values") 
-    %test:arg("lang", "foo1g4#lang") %test:assertEmpty
+    %test:arg("lang", "foo1g4#lang") %test:assertError("eutil:InvalidLanguageCodeError")
     function eut:test-getLanguageString-3-arity($key as xs:string, $values as xs:string*, $lang as xs:string) as xs:string? {
         eutil:getLanguageString($key, $values, $lang)
 };
@@ -103,12 +103,12 @@ declare
     (: Test replacements with existing key without placeholders :)
     %test:args("xmldb:exist:///db/apps/Edirom-Online-Backend/testing/XQSuite/data/language-de.xml", "global_cancel", "foo", "de") %test:assertEquals("Test-Abbrechen")
     (: Test replacements with existing key and non-existing language :)
-    %test:args("", "global_cancel", "foo", "foo1g4#lang") %test:assertEmpty
+    %test:args("", "global_cancel", "foo", "foo1g4#lang") %test:assertError("eutil:InvalidLanguageCodeError")
     (: Test empty replacements with non-existing key and non-existing language :)
     %test:arg("langFileURI", "")
     %test:arg("key", "foo1g4#")
     %test:arg("values") 
-    %test:arg("lang", "foo1g4#lang") %test:assertEmpty
+    %test:arg("lang", "foo1g4#lang") %test:assertError("eutil:InvalidLanguageCodeError")
     (: Test empty replacements with existing key from default language file :)
     %test:arg("langFileURI", "xmldb:exist:///db/apps/Edirom-Online-Backend/testing/XQSuite/data/language-de.xml")
     %test:arg("key", "view.desktop.Desktop_Maximize")


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->

The language information was only inconsistently propagated to various functions. This PR tries to remedy this by introducing a new function `eutil:getSetLanguage#1` as a replacement for `eutil:getLanguage#0`.

This function accepts an optional `$lang` parameter for setting the language and validates this value against the available langFiles at `/data/locale`.
If a `$lang` parameter is provided and it is supported by some langFile, the same value will be returned and saved to the current session. If the provided value is not supported, an error will be raised.
If no `$lang` parameter is provided (i.e. `$lang` equals the empty-sequence), the function will try to determine the language in the following order:
1. from the HTTP request parameter "lang"
2. from the session attribute "lang"
3. from the preferred browser language as provided in the "Accept-Language" header
4. from the first supported language provided by `$eutil:supported-languages`

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs #148 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
Tested it locally 

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Improvement
- Refactoring

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Backend/blob/develop/CONTRIBUTING.md) document.
- I have added tests to cover my changes at [testing](https://github.com/Edirom/Edirom-Online-Backend/tree/develop/testing)
- All new and existing tests passed.
