### PR TITLE
Webcomponents can be configured within the prefs.xml

### DIFF
--- a/data/prefs/edirom-prefs.xml
+++ b/data/prefs/edirom-prefs.xml
@@ -30,4 +30,13 @@
         <entry key="start_documents_uri" value=""/>
         <entry key="gotomenu_display" value="partwise"/>
     </entries>
+    <!-- <web-components>
+        <web-component key="edirom_keycloak_handler">
+            <option key="url" value="https://keycloak.edirom.de" />
+            <option key="realm" value="realmName" />
+            <option key="client_id" value="resource-name" />
+            <option key="script"
+                value="resources/web-components/edirom-keycloak-handler/keycloak-handler.js" />
+        </web-component>
+    </web-components> -->
 </prefs>

--- a/data/xql/getPreferences.xql
+++ b/data/xql/getPreferences.xql
@@ -52,7 +52,7 @@ return
                     map:merge(
                         ($file//*[local-name() = 'web-component'], $projectFile//*[local-name() = 'web-component']) ! map:entry(./string(@key),
                             map:merge(
-                                .//option ! map:entry(./string(@key), ./string(@value))
+                                .//(pref:option|option) ! map:entry(./string(@key), ./string(@value))
                             )
                         )
                     )

--- a/data/xql/getPreferences.xql
+++ b/data/xql/getPreferences.xql
@@ -46,7 +46,17 @@ return
         let $data := 
             map:merge((
                 $file//(pref:entry|entry) ! map:entry(./string(@key), ./string(@value)), 
-                $projectFile//(pref:entry|entry) ! map:entry(./string(@key), ./string(@value))  
+                $projectFile//(pref:entry|entry) ! map:entry(./string(@key), ./string(@value)),
+                map:entry(
+                    "web-components",
+                    map:merge(
+                        ($file//*[local-name() = 'web-component'], $projectFile//*[local-name() = 'web-component']) ! map:entry(./string(@key),
+                            map:merge(
+                                .//option ! map:entry(./string(@key), ./string(@value))
+                            )
+                        )
+                    )
+                ) 
             ))
         return
             response:stream($data => serialize($outputOptions), $serializationParameters)


### PR DESCRIPTION
## Description, Context and related Issue

This change adds the ability to configure web-components directly within the `prefs.xml` file. Web-components can now be defined with key-value option pairs, allowing for flexible and centralized configuration management.

### Changes Made:
1. **edirom-prefs.xml**: Added a commented example demonstrating how web-components can be configured (e.g., `edirom_keycloak_handler` with URL, realm, client ID, and script path)
2. **getPreferences.xql**: Enhanced the preferences retrieval logic to parse and return web-component configurations along with their options as a structured map

This enables applications to:
- Dynamically load and configure web-components through the preferences system
- Support multiple web-components with their individual settings

Closes #165 

## How Has This Been Tested?

- With and without custom `prefs.xml`
- With and without web-components entry in `prefs.xml`

## Types of changes

- New feature (non-breaking change which adds functionality)
- Improvement

## Overview

- [x] I have updated the inline documentation accordingly.
- [x] I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- [x] I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Backend/blob/develop/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes at [testing](https://github.com/Edirom/Edirom-Online-Backend/tree/develop/testing)
- [ ] All new and existing tests passed.