### PR TITLE
adds search for MEI gt 3 and html

### DIFF
--- a/data/xql/search.xql
+++ b/data/xql/search.xql
@@ -13,6 +13,7 @@ import module namespace edition = "http://www.edirom.de/xquery/edition" at "../x
 
 (: NAMESPACE DECLARATIONS ================================================== :)
 
+declare namespace html = "http://www.w3.org/1999/xhtml";
 declare namespace mei = "http://www.music-encoding.org/ns/mei";
 declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace request = "http://exist-db.org/xquery/request";
@@ -85,6 +86,12 @@ let $return :=
                 | edition:collection($edition)//mei:title[ft:query(., $term)]/ancestor::mei:mei
                 | edition:collection($edition)//mei:annot[ft:query(., $term)][@type eq 'editorialComment']
                 | edition:collection($edition)//mei:annot[contains(@xml:id, $term)]
+                (: HTML documents — with XHTML namespace :)
+                | edition:collection($edition)//html:body[ft:query(., $term)]/ancestor::html:html
+                | edition:collection($edition)//html:title[ft:query(., $term)]/ancestor::html:html
+                (: HTML documents — without namespace (DOCTYPE html) :)
+                | edition:collection($edition)/html[ft:query(.//body, $term)]
+                | edition:collection($edition)/html[ft:query(.//title, $term)]
             ) else
                 ()
         return (
@@ -106,15 +113,39 @@ let $return :=
                 
                 (: Work :)
                 else if (exists($doc//mei:mei) and exists($doc//mei:work)) then
-                    (eutil:getLocalizedTitle($doc//mei:work/mei:titleStmt, $lang))
+                    (: MEI3: titleStmt exists inside mei:work :)
+                    if (exists($doc//mei:work/mei:titleStmt)) then
+                        eutil:getLocalizedTitle($doc//mei:work/mei:titleStmt, $lang)
+                    (: MEI4/5: title is a direct child of mei:work :)
+                    else if (exists($doc//mei:work/mei:title)) then
+                        eutil:getLocalizedTitle($doc//mei:work, $lang)
+                    (: fallback: use fileDesc/titleStmt :)
+                    else
+                        eutil:getLocalizedTitle($doc//mei:meiHead/mei:fileDesc/mei:titleStmt, $lang)
                 
                 (: Source / Score :)
                 else if (exists($doc//mei:mei) and exists($doc//mei:source)) then
-                    (eutil:getLocalizedTitle($doc//mei:source/mei:titleStmt, $lang))
+                    (: MEI3: titleStmt exists inside mei:source :)
+                    if (exists($doc//mei:source/mei:titleStmt)) then
+                        eutil:getLocalizedTitle($doc//mei:source/mei:titleStmt, $lang)
+                    (: MEI4/5: title is a direct child of mei:source :)
+                    else if (exists($doc//mei:source/mei:title)) then
+                        eutil:getLocalizedTitle($doc//mei:source, $lang)
+                    (: fallback: use fileDesc/titleStmt :)
+                    else
+                        eutil:getLocalizedTitle($doc//mei:meiHead/mei:fileDesc/mei:titleStmt, $lang)
                 
                 (: Text :)
                 else if (exists($doc/tei:TEI)) then
                     (eutil:getLocalizedTitle($doc//tei:titleStmt, $lang))
+                
+                (: HTML with XHTML namespace :)
+                else if (exists($doc/html:html)) then
+                    (string(($doc//html:title)[1]))
+                
+                (: HTML without namespace :)
+                else if (exists($doc/html)) then
+                    (string(($doc//title)[1]))
                 
                 else
                     (string('unknown'))


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
Trying to display the search results for MEI, it was looking for `titleStmt` that is not allowed in `work` anymore since MEI 4.0 (for details see explanation at #167 ), but data in EditionExample is MEI 5.
The EditionExample also has html code, but the search was not searching in html files so far. 

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs #167 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
Build the backend and tried to search for words, e.g. "Stechereivermerk" (MEI), "Vorwort" (html). And use EditionExample with changes from https://github.com/Edirom/EditionExample/pull/36
<img width="1394" height="857" alt="Bildschirmfoto 2026-04-24 um 14 02 31" src="https://github.com/user-attachments/assets/b262efff-2c30-4804-8ed1-185cbcde89b7" />
<img width="1209" height="643" alt="Bildschirmfoto 2026-04-24 um 14 32 02" src="https://github.com/user-attachments/assets/cf5bd4fb-9281-4ba3-903f-f140926da1b9" />


## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the inline documentation accordingly.
- [x] I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- [x] I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Backend/blob/develop/CONTRIBUTING.md) document.
