### PR TITLE
getHelp.xql: make stylesheet parameters closer to getText.xql

### DIFF
--- a/data/xql/getHelp.xql
+++ b/data/xql/getHelp.xql
@@ -24,12 +24,9 @@ let $idPrefix := request:get-parameter('idPrefix', '')
 
 let $base := replace(system:get-module-load-path(), 'embedded-eXist-server', '') (:TODO:)
 
-let $doc := doc(concat('../../help/help_', $lang, '.xml'))
-let $contextPath := if(starts-with(document-uri($doc), '/db'))
-                    then substring-after(document-uri($doc), '/db')
-                    else document-uri($doc)
-let $contextPath := substring-before($contextPath, concat('help/help_', $lang, '.xml'))
-let $contextPath := request:get-context-path() || $contextPath
+let $uri := concat('xmldb:exist:///db/apps/Edirom-Online-Backend/help/help_', $lang, '.xml')
+let $doc := doc($uri)
+let $contextPath := request:get-scheme()|| "://" || request:get-server-name() || ":" || request:get-server-port() || request:get-context-path()
 
 let $xsl := doc('../xslt/edirom_langReplacement.xsl')
 let $doc := 
@@ -47,10 +44,8 @@ let $doc :=
             <param name="base" value="{concat($base, '/../xslt/')}"/>
             <param name="lang" value="{$lang}"/>
             <param name="tocDepth" value="1"/>
-            (: == passing empty value for docUri (XSLT expects xs:anyURI, but ExtJS view does not provide value) -> github#480 == :)
             <param name="contextPath" value="{$contextPath}"/>
-            (: == passing empty value for docUri (XSLT expects xs:anyURI, but ExtJS view does not provide value) -> github#480 == :)
-            <param name="docUri" value="''"/>
+            <param name="docUri" value="{$uri}"/>
         </parameters>
     )
 

--- a/help/help_de.xml
+++ b/help/help_de.xml
@@ -56,7 +56,7 @@
                Der Bereich dazwischen ist der <term type="ediromGui" key="view.desktop.Desktop"/>, innerhalb dessen alle innenliegenden Anwendungsfenster geöffnet werden um den Inhalt einer Edition anzuzeigen und Zugang zu weiteren Funktionen zu erhalten. Rechts befindet sich die <ptr target="#navigator"/>.
             </p>
             <figure>
-               <graphic url="help/images/fullscreen_en.png"/>
+               <graphic url="images/fullscreen_en.png"/>
                <head>Eine exemplarische Ansicht des <term type="ediromGui" key="global_appName"/> Fensters, das die <term type="ediromGui" key="view.desktop.TopBar"/> (oben), die <term type="ediromGui" key="view.desktop.TaskBar"/> (unten), den <term type="ediromGui" key="view.desktop.Desktop"/> und die <term type="ediromGui" key="view.navigator.Navigator"/> (rechts) zeigt.</head>
             </figure>
             
@@ -70,7 +70,7 @@
                   Rechts befindet sich die Eingabe für die <ptr target="#search"/>.
                </p>
                <figure>
-                  <graphic url="help/images/menubar_en.png"/>
+                  <graphic url="images/menubar_en.png"/>
                   <head>Detailansicht der <term type="ediromGui" key="view.desktop.TopBar"/> mit <term type="ediromGui" key="view.desktop.TopBar_homeBtn"/> und <term type="ediromGui" key="comboBox"/> für die Werkauswahl (links) und dem Suchfeld (rechts).
                   </head>
                </figure>
@@ -81,14 +81,14 @@
                   <p>Das <term type="ediromGui" key="view.desktop.TaskBar_search"/> Fenster kann durch das Klicken des <term type="ediromGui" key="view.desktop.TaskBar_search"/>-Buttons (Lupe) in der <term type="ediromGui" key="view.desktop.TopBar"/> oder durch die Eingabe einer Suchanfrage in das <term type="ediromGui" key="view.desktop.TopBar_searchField"/> geöffnet werden.
                      Es wird eine text-basierte Suche auf allen Inhalten der Edition ausgeführt.</p>
                   <figure>
-                     <graphic url="help/images/searchField.png"/>
+                     <graphic url="images/searchField.png"/>
                      <head>Detailansicht vom <term type="ediromGui" key="view.desktop.TopBar_searchField"/>: Ein Klick auf die Lupe löst den Befehl <term type="ediromGui" key="view.desktop.TaskBar_searchWin"/> aus.</head>
                   </figure>   
                   <p>Nachdem eine Suchanfrage ausgeführt wurde, werden alle Ergebnisse mit entsprechenden Inhalten (Textdokument, Annotation, usw.) gruppiert.
                      Einzelne Suchergebnisse werden gegebenenfalls extra hervorgehoben.
                      Sollte eine Suchanfrage mehr als drei Treffer pro Eintrag ergeben, erscheint ein <q>Zeige alle Treffer</q> Link.</p>
                   <figure>
-                     <graphic url="help/images/searchWindow_en.png"/>
+                     <graphic url="images/searchWindow_en.png"/>
                      <head>Das <term type="ediromGui" key="view.window.search.SearchWindow_Title"/> Fenster</head>
                   </figure>
                </div>
@@ -103,7 +103,7 @@
                   Die <term type="ediromGui" key="view.navigator.Navigator"/> enthält eine editionsspezifische Liste von Objekten, die in Kategorien organisiert sein können. 
                   Wird ein Element in der Liste angeklickt, öffnet sich das dazugehörige Objekt in einem Fenster des <term type="ediromGui" key="view.desktop.Desktop"/>.</p>
                <figure>
-                  <graphic url="help/images/navigator_en.png"/>
+                  <graphic url="images/navigator_en.png"/>
                   <head>Eine exemplarische <term type="ediromGui" key="view.navigator.Navigator"/></head>
                </figure>
                <p>Beinhaltet die <term type="ediromGui" key="view.navigator.Navigator"/> viele Objekte, kann mit dem Scrollbalken am rechten Rand des Fensters durch die Inhalte navigiert werden.
@@ -117,46 +117,46 @@
                </head>
                <p>Durch die <term type="ediromGui" key="view.desktop.TaskBar"/> am unteren Rand des <term type="ediromGui" key="view.desktop.Desktop"/>s kann auf die globalen inhaltsbezogenen Funktionen auf der linken Seite sowie die Meta-Funktionen auf der rechten Seite zugegriffen werden.</p>
                <figure>
-                  <graphic url="help/images/taskBar_en.png"/>
+                  <graphic url="images/taskBar_en.png"/>
                   <head>Detaillierte Ansicht der <term type="ediromGui" key="view.desktop.TaskBar"/></head>
                </figure>
                <p>Die drei ersten Buttons links steuern die unterschiedliche Anordnung aller geöffneten Inhaltsfenster auf dem <term type="ediromGui" key="view.desktop.Desktop"/>.</p>
                <figure>
-                  <graphic url="help/images/arrangeButtons_grid.png"/>
+                  <graphic url="images/arrangeButtons_grid.png"/>
                   <head><term type="ediromGui" key="view.desktop.TaskBar_Sort_grid"/></head>
                </figure>
                <figure>
-                  <graphic url="help/images/arrangeButtons_horizontal.png"/>
+                  <graphic url="images/arrangeButtons_horizontal.png"/>
                   <head><term type="ediromGui" key="view.desktop.TaskBar_Sort_horizontal"/></head>
                </figure>
                <figure>
-                  <graphic url="help/images/arrangeButtons_vertical.png"/>
+                  <graphic url="images/arrangeButtons_vertical.png"/>
                   <head><term type="ediromGui" key="view.desktop.TaskBar_Sort_vertical"/></head>
                </figure>
                <p>Die <term type="ediromGui" key="Bar"/>e von Faksimiles und Noteneditionen sind meistens mit Nummern versehen, diese können mit dem vierten Button von links für alle geöffneten Fenster mit musikalischem Inhalt ein- und ausgeblendet werden.</p>
                <figure>
-                     <graphic url="help/images/measureNumbers.png"/>
+                     <graphic url="images/measureNumbers.png"/>
                      <head><term type="ediromGui" key="view.desktop.TaskBar_measureNumbers"/></head>
                </figure>
                <p>Noteneditionen bzw. Faksimiles und Librettoeditionen können Anmerkungen enthalten, die durch Annotationssymbole geöffnet werden können.
                   Mit dem Sprechblase-Button lassen sich <term type="ediromGui" key="view.desktop.TaskBar_annotations"/>.
                   Anmerkungen können Prioritäten und Kategorien zugeordnet sein. Das Filtern von Anmerkungen nach diesen Prioritäten und Anmerkungen ist über den globalen Button in der <term type="ediromGui" key="view.desktop.TaskBar"/> nicht möglich, sondern nur über die Auswahl an einem individuellen Fenster.</p>
                <figure>
-                  <graphic url="help/images/annotations.png"/>
+                  <graphic url="images/annotations.png"/>
                   <head><term type="ediromGui" key="view.desktop.TaskBar_annotations"/></head>
                </figure>
                <p>Der Button mit den zwei horizontalen Pfeilen löst den Befehl <term type="ediromGui" key="view.desktop.TaskBar_concordanceNav"/> aus und es öffnet sich der Navigator für <ptr target="#concordanceNavigator"/>, Details zur Bedienung des Konkordanz-Navigators finden sich im entsprechenden Abschnitt.</p>
                <figure>
-                     <graphic url="help/images/concordanceNavigator.png"/>
+                     <graphic url="images/concordanceNavigator.png"/>
                      <head><term type="ediromGui" key="view.desktop.TaskBar_concordanceNav"/></head>
                </figure>
                <p>Am rechten unteren Rand kann mit dem i (wie Info) Button ein <term type="ediromGui" key="view.desktop.TaskBar_about"/>-Fenster geöffnet werden und mit dem Fragezeichen-Button kann die <term type="ediromGui" key="view.desktop.TaskBar_help"/> geöffnet bzw. in den Vordergrund verschoben werden.</p>
                <figure>
-                  <graphic url="help/images/about.png"/>
+                  <graphic url="images/about.png"/>
                   <head><term type="ediromGui" key="view.desktop.TaskBar_about"/></head>
                </figure>
                <figure>
-                  <graphic url="help/images/help.png"/>
+                  <graphic url="images/help.png"/>
                   <head><term type="ediromGui" key="view.desktop.TaskBar_help"/></head>
                </figure>
             </div>
@@ -173,8 +173,8 @@
                Sollte die ausgewählte Konkordanz weitere Untergliederungen, wie z.B. Sätze, beinhalten, wird ein zweites Drop-Down-Menü zur Auswahl erscheinen.
             </p>
             <figure>
-               <graphic url="help/images/concNav_en.png"/>
-               <graphic url="help/images/concNav2_en.png"/>
+               <graphic url="images/concNav_en.png"/>
+               <graphic url="images/concNav2_en.png"/>
                <head>
                   <term type="ediromGui" key="view.desktop.TaskBar_concordanceNav"/> mit und ohne zusätzliches Drop-Down-Menü.</head>
             </figure>
@@ -259,54 +259,54 @@
                   </head>
                   <p>Die <term type="ediromGui" key="view.window.BottomBar"/> enthält folgende Werkzeuge für die Navigation innerhalb des Inhalts der Quellen:</p>
                   <figure>
-                     <graphic url="help/images/pageView.png"/>
+                     <graphic url="images/pageView.png"/>
                      <head><term type="ediromGui" key="view.window.source.SourceView_PageBasedView"/></head>
                      <p>Wechselt zu einer seitenbasierten Navigation der Quelle.</p>
                   </figure>
                   <figure>
-                     <graphic url="help/images/barView.png"/>
+                     <graphic url="images/barView.png"/>
                      <head><term type="ediromGui" key="view.window.source.SourceView_MeasureBasedView"/></head>
                      <p>Wechselt zu einer <term type="ediromGui" key="Bar"/>basierten Navigation der Quelle. Bei Aktivierung dieser Ansicht erscheinen die zusätzliche Werkzeuge in der <term type="ediromGui" key="view.window.BottomBar"/> (siehe Beschreibungen weiter unten).</p>
                   </figure>
                   <figure>
-                     <graphic url="help/images/prev-box-next.png"/>
+                     <graphic url="images/prev-box-next.png"/>
                      <head><term type="ediromGui" key="view.window.source.SourceView_PageBasedView_pageSpinner"/> or <term type="ediromGui" key="view.window.source.SourceView_MeasureBasedView_measureSpinner"/></head>
                      <p>Die Zahl im Nummernfeld zeigt die derzeitige Seitenzahl (<term type="ediromGui" key="view.window.source.SourceView_PageBasedView"/>) oder <term type="ediromGui" key="Bar"/>zahl (<term type="ediromGui" key="view.window.source.SourceView_MeasureBasedView"/>) an.
                         Das Wechseln auf eine andere Seite oder einen anderen <term type="ediromGui" key="Bar"/> ist durch das Klicken auf die Pfeilköpfe oder die Eingabe einer Zahl in das Nummernfeld möglich.
                            Die möglichen Zahlen korrespondieren mit der Quelle, beginnen also nicht immer mit 1 und können auch alphanumerische Charaktere enthalten.</p>
                   </figure>
                   <figure>
-                     <graphic url="help/images/slider.png"/>
+                     <graphic url="images/slider.png"/>
                      <head><term type="ediromGui" key="view.window.source.SourceView_PageBasedView"/>, <term type="ediromGui" key="view.window.source.SourceView_zoomSlider"/></head>
                      <p>Anpassung des Zoom-Levels für die geöffnete Quelle.</p>
                   </figure>
                   <figure>
-                     <graphic url="help/images/SourceView_measureBasedCombo.png"/>
+                     <graphic url="images/SourceView_measureBasedCombo.png"/>
                      <head><term type="ediromGui" key="view.window.source.SourceView_MeasureBasedView"/>, <term type="ediromGui" key="view.window.source.SourceView_measureBasedCombo"/></head>
                      <p>Es kann der Satz ausgewählt werden, dessen <term type="ediromGui" key="Bar"/>e angezeigt werden sollen.</p>
                   </figure>
                   <figure>
-                     <graphic url="help/images/SourceView_measureBasedRange.png"/>
+                     <graphic url="images/SourceView_measureBasedRange.png"/>
                      <head><term type="ediromGui" key="view.window.source.SourceView_MeasureBasedView"/>, <term type="ediromGui" key="view.window.source.SourceView_measureBasedRange"/></head>
                      <p>Eingabe eines <term type="ediromGui" key="Bar"/>-Umfangs, durch den "geblättert" werden soll.</p>
                   </figure>
                   <figure>
-                     <graphic url="help/images/selectVoices.png"/>
+                     <graphic url="images/selectVoices.png"/>
                      <head><term type="ediromGui" key="view.window.source.SourceView_MeasureBasedView"/>, <term type="ediromGui" key="view.window.source.SourceView_MeasureBasedView_selectVoices"/></head>
                      <p>Es können einzelne Stimmen ausgewählt werden. Dieses Werkzeug ist nur verfügbar, wenn verschiedene Stimmen in der Codierung gekennzeichnet sind.</p>
                   </figure>
                   <figure>
-                     <graphic url="help/images/measureNumbers.png"/>
+                     <graphic url="images/measureNumbers.png"/>
                      <head><term type="ediromGui" key="view.desktop.TaskBar_measureNumbers"/></head>
                      <p>Die <term type="ediromGui" key="Bar"/>e von Faksimiles und Noteneditionen sind meistens mit Nummern versehen, und können mit diesem Button ein- und ausgeblendet werden. Die Einstellung für das Fenster wird überschrieben, wenn der global Button verwendet wird.</p>
                   </figure>
                   <figure>
-                     <graphic url="help/images/annotations.png"/>
+                     <graphic url="images/annotations.png"/>
                      <head><term type="ediromGui" key="view.desktop.TaskBar_annotations"/></head>
                     <p>Mit dem Sprechblase-Button lassen sich <term type="ediromGui" key="view.desktop.TaskBar_annotations"/>. Die Einstellung für das Fenster wird überschrieben, wenn der global Button verwendet wird.</p>
                   </figure>
                   <figure>
-                     <graphic url="help/images/zoom-fit.png"/>
+                     <graphic url="images/zoom-fit.png"/>
                      <head><term type="ediromGui" key="view.window.source.SourceView_fitView"/></head>
                      <p>Passt die Größe der aktuellen Quelle an das Fenster an.</p>
                   </figure>
@@ -378,23 +378,23 @@
                </p><lb/>
                <p>Die <term type="ediromGui" key="view.window.BottomBar"/> enthält folgende Werkzeuge.</p>
                <figure>
-                  <graphic url="help/images/view-list-details-symbolic.png"/>
+                  <graphic url="images/view-list-details-symbolic.png"/>
                   <head>(Rückkehr zur) <term type="ediromGui" key="view.window.AnnotationView_ListView"/></head>
                </figure>
                <figure>
-                  <graphic url="help/images/go-previous.png"/>
+                  <graphic url="images/go-previous.png"/>
                   <head><term type="ediromGui" key="view.window.AnnotationView_PreviousAnnotation"/> aus der Anmerkungsliste.</head>
                </figure>
                 <figure>
-                   <graphic url="help/images/go-next.png"/>
+                   <graphic url="images/go-next.png"/>
                    <head><term type="ediromGui" key="view.window.AnnotationView_NextAnnotation"/> aus der Anmerkungsliste.</head>
                </figure>
                <figure>
-                  <graphic url="help/images/openAllWindows.png"/>
+                  <graphic url="images/openAllWindows.png"/>
                   <head><term type="ediromGui" key="view.window.AnnotationView_OpenAll"/>: Öffnet die detaillierte Ansicht aller Quellen, die in Zusammenhang mit der aktuell ausgewählte Annotation stehen.</head>
                </figure>
                <figure>
-                  <graphic url="help/images/closeAllWindows.png"/>
+                  <graphic url="images/closeAllWindows.png"/>
                   <head><term type="ediromGui" key="view.window.AnnotationView_CloseAll"/>: Nur verfügbar, wenn <term type="ediromGui" key="view.window.AnnotationView_OpenAll"/> vorhergehend ausgeführt wurde.</head>
                </figure>
             </div>
@@ -410,7 +410,7 @@
                Der Gebrauch dieser Optionen hängt von den Editionsrichtlinen ab (z.B. den Kategorien, die tatsächlich verwendet wurden). 
                Deshalb sollte die folgende Beschreibung nicht als komplette Dokumentation gesehen werden, sondern eher als eine Einführung in die grundsätzlichen Konzepte dieser Überlegung.</p>
             <figure>
-               <graphic url="help/images/annotationOverview.png"/>
+               <graphic url="images/annotationOverview.png"/>
                <head>Ein exemplarischer Screenshot eines Annotationssymbols, das den Tooltip einer einzelnen Annotation zeigt.</head>
             </figure>
             
@@ -420,15 +420,15 @@
                <p>Eine <term type="ediromGui" key="view.window.AnnotationView_Priority"/> gibt einen Hinweis auf die Wichtigkeit der Annotation.
                   Die Visualisierung der <term type="ediromGui" key="view.window.AnnotationView_Priority"/> im <ptr target="#facsimileView"/> wird durch eine Farbcodierung der Symbole erreicht:</p>
                <figure>
-                  <graphic url="help/images/annotGeneric1.png"/>
+                  <graphic url="images/annotGeneric1.png"/>
                   <p><hi rend="italic">Priorität 1</hi> Annotationen beziehen sich auf die editionsspezifischen Schlüsselprobleme und sind mit der Farbe rot markiert.</p>
                </figure>
                <figure>
-                  <graphic url="help/images/annotGeneric2.png"/>
+                  <graphic url="images/annotGeneric2.png"/>
                   <p><hi rend="italic">Priorität 2</hi> Annotationen beziehen sich auf wichtige Aspekte der Edition, die aber nicht von größter Bedeutung für die Edition sind und sind orange markiert.</p>
                </figure>
                <figure>
-                  <graphic url="help/images/annotGeneric3.png"/>
+                  <graphic url="images/annotGeneric3.png"/>
                   <p><hi rend="italic">Priorität 3</hi> Annotationen enthalten editorische Beobachtungen, die normalerweise nur für die Dokumentquellen interessant sind. Diese Annotationen sind mit gelb markiert.</p>
                </figure>
             </div>
@@ -451,9 +451,9 @@
                         <cell>Partitur</cell>
                         <cell>
                            <figure>
-                              <graphic url="help/images/annotNotation1.png"/>
-                              <graphic url="help/images/annotNotation2.png"/>
-                              <graphic url="help/images/annotNotation3.png"/>
+                              <graphic url="images/annotNotation1.png"/>
+                              <graphic url="images/annotNotation2.png"/>
+                              <graphic url="images/annotNotation3.png"/>
                            </figure>
                         </cell>
                      </row>
@@ -461,9 +461,9 @@
                         <cell>Expressive Kennzeichnung</cell>
                         <cell>
                            <figure>
-                              <graphic url="help/images/annotExpr1.png"/>
-                              <graphic url="help/images/annotExpr2.png"/>
-                              <graphic url="help/images/annotExpr3.png"/>
+                              <graphic url="images/annotExpr1.png"/>
+                              <graphic url="images/annotExpr2.png"/>
+                              <graphic url="images/annotExpr3.png"/>
                            </figure>
                         </cell>
                      </row>
@@ -471,9 +471,9 @@
                         <cell>Choral Text</cell>
                         <cell>
                            <figure>
-                              <graphic url="help/images/annotText1.png"/>
-                              <graphic url="help/images/annotText2.png"/>
-                              <graphic url="help/images/annotText3.png"/>
+                              <graphic url="images/annotText1.png"/>
+                              <graphic url="images/annotText2.png"/>
+                              <graphic url="images/annotText3.png"/>
                             </figure>
                         </cell>
                      </row>
@@ -481,9 +481,9 @@
                         <cell>Kombination verschiedener Kategorien</cell>
                         <cell>
                            <figure>
-                              <graphic url="help/images/annotGeneric1.png"/>
-                              <graphic url="help/images/annotGeneric2.png"/>
-                              <graphic url="help/images/annotGeneric3.png"/>
+                              <graphic url="images/annotGeneric1.png"/>
+                              <graphic url="images/annotGeneric2.png"/>
+                              <graphic url="images/annotGeneric3.png"/>
                            </figure>
                         </cell>
                      </row>

--- a/help/help_en.xml
+++ b/help/help_en.xml
@@ -71,7 +71,7 @@
                   The area in between is the <term type="ediromGui" key="view.desktop.Desktop"/>, within which all internal application windows are opened to display the content of an edition and gain access to additional functions. On the right is the <ptr target="#navigator"/>
                </p>
                <figure>
-                  <graphic url="help/images/fullscreen_en.png"/>
+                  <graphic url="images/fullscreen_en.png"/>
                   <head>An example view of the <term type="ediromGui" key="global_appName"/> window, which shows the <term type="ediromGui" key="view.desktop.TopBar"/> (top), the <term type="ediromGui" key="view.desktop.TaskBar"/> (bottom), the <term type="ediromGui" key="view.desktop.Desktop"/> and the <term type="ediromGui" key="view.navigator.Navigator"/> (right).</head>
                </figure>
                
@@ -86,7 +86,7 @@
                       On the right is the input for the <ptr target="#search"/>.
                    </p>
                   <figure>
-                     <graphic url="help/images/menubar_en.png"/>
+                     <graphic url="images/menubar_en.png"/>
                      <head>Detailed view of the <term type="ediromGui" key="view.desktop.TopBar"/> with <term type="ediromGui" key="view.desktop.TopBar_homeBtn"/> and <term type="ediromGui" key="comboBox"/> for the work selection (left) and the search field (right).</head>
                   </figure>
                   <div type="div3" xml:id="search">
@@ -96,14 +96,14 @@
                      <p>The <term type="ediromGui" key="view.desktop.TaskBar_search"/> window can be opened by clicking the <term type="ediromGui" key="view.desktop.TaskBar_search"/> button (magnifying glass) in the <term type="ediromGui" key="view.desktop.TopBar"/> or by entering a search query in the <term type="ediromGui" key="view.desktop.TopBar_searchField"/>.
                         A text-based search is performed on all content in the edition.</p>
                      <figure>
-                        <graphic url="help/images/searchField.png"/>
+                        <graphic url="images/searchField.png"/>
                         <head>Detailed view of the <term type="ediromGui" key="view.desktop.TopBar_searchField"/>: Clicking on the magnifying glass triggers the <term type="ediromGui" key="view.desktop.TaskBar_searchWin"/> command.</head>
                      </figure>
                      <p>After a search query is executed, all results are grouped with corresponding content, eg text document, annotation.
                         Individual search results may be highlighted separately.
                         If a search query results in more than three hits per entry, a <q>Show all hits</q> link appears.</p>
                      <figure>
-                        <graphic url="help/images/searchWindow_en.png"/>
+                        <graphic url="images/searchWindow_en.png"/>
                         <head>The <term type="ediromGui" key="view.window.search.SearchWindow_Title"/> window</head>
                      </figure>
                    </div>
@@ -118,7 +118,7 @@
                      The <term type="ediromGui" key="view.navigator.Navigator"/> contains an edition-specific list of objects that can be organized into categories. 
                      If an element in the list is clicked, the corresponding object opens in a window of the <term type="ediromGui" key="view.desktop.Desktop"/>.</p>
                   <figure>
-                     <graphic url="help/images/navigator_en.png"/>
+                     <graphic url="images/navigator_en.png"/>
                      <head>An exemplary <term type="ediromGui" key="view.navigator.Navigator"/></head>
                   </figure>
                   <p>If the <term type="ediromGui" key="view.navigator.Navigator"/> contains many objects, you can navigate through the contents using the scroll bar on the right edge of the window.
@@ -132,54 +132,54 @@
                   </head>
                   <p>Through the <term type="ediromGui" key="view.desktop.TaskBar"/> at the bottom of the <term type="ediromGui" key="view.desktop.Desktop"/> the global content-related functions can be accessed on the left and the meta functions on the right.</p>
                   <figure>
-                     <graphic url="help/images/taskBar_en.png"/>
+                     <graphic url="images/taskBar_en.png"/>
                      <head>Detailed view of the <term type="ediromGui" key="view.desktop.TaskBar"/></head>
                   </figure>
                   <p>The first three buttons on the left control the different arrangement of all open content windows on the <term type="ediromGui" key="view.desktop.Desktop"/>.</p>
                   <figure>
-                     <graphic url="help/images/arrangeButtons_grid.png"/>
+                     <graphic url="images/arrangeButtons_grid.png"/>
                      <head><term type="ediromGui" key="view.desktop.TaskBar_Sort_grid"/></head>
                   </figure>
                   <figure>
-                     <graphic url="help/images/arrangeButtons_horizontal.png"/>
+                     <graphic url="images/arrangeButtons_horizontal.png"/>
                      <head><term type="ediromGui" key="view.desktop.TaskBar_Sort_horizontal"/></head>
                   </figure>
                   <figure>
-                     <graphic url="help/images/arrangeButtons_vertical.png"/>
+                     <graphic url="images/arrangeButtons_vertical.png"/>
                      <head><term type="ediromGui" key="view.desktop.TaskBar_Sort_vertical"/></head>
                   </figure>
                   <p>The <term type="ediromGui" key="Bar"/>s of facsimiles and editions are usually provided with numbers; these can be shown and hidden for all open windows with musical content using the fourth button from the left.</p>
                   <figure>
-                     <graphic url="help/images/measureNumbers.png"/>
+                     <graphic url="images/measureNumbers.png"/>
                      <head><term type="ediromGui" key="view.desktop.TaskBar_measureNumbers"/></head>
                   </figure>
                   <p>Music editions or facsimiles and libretto editions can contain annotations that can be opened using annotation symbols.
                      With the speech bubble button you can <term type="ediromGui" key="view.desktop.TaskBar_annotations"/>.
                      Annotations can be assigned priorities and categories. Filtering annotations according to these priorities and annotations is not possible via the global button in the <term type="ediromGui" key="view.desktop.TaskBar"/>, but only via selection in an individual window.</p>
                   <figure>
-                     <graphic url="help/images/annotations.png"/>
+                     <graphic url="images/annotations.png"/>
                      <head><term type="ediromGui" key="view.desktop.TaskBar_annotations"/></head>
                   </figure>
                   <!-- Presently not in use ... -->
                   <!--
                   <p>The <term type="ediromGui" key="view.desktop.Desktop"/> button opens a new <term type="ediromGui" key="view.desktop.Desktop"/> in <term type="ediromGui" key ="global_appName"/>. This will open a completely new set of windows without changing the contents of the current desktop.</p>
                   <figure>
-                     <graphic url="help/images/workspace-switcher.png"/>
+                     <graphic url="images/workspace-switcher.png"/>
                      <head><term type="ediromGui" key="view.desktop.Desktop"/></head>
                   </figure>
                   -->
                   <p>The button with the two horizontal arrows triggers the <term type="ediromGui" key="view.desktop.TaskBar_concordanceNav"/> command, and the navigator for <ptr target="#concordanceNavigator"/> opens. Details on how to use the concordance navigator can be found in the corresponding section.</p>
                   <figure>
-                     <graphic url="help/images/concordanceNavigator.png"/>
+                     <graphic url="images/concordanceNavigator.png"/>
                      <head><term type="ediromGui" key="view.desktop.TaskBar_concordanceNav"/></head>
                   </figure>
                   <p>At the bottom right, you can use the i (as info) button that opens an <term type="ediromGui" key="view.desktop.TaskBar_about"/> window and the question mark button to open the <term type="ediromGui" key="view.desktop.TaskBar_help"/> or move it to the foreground.</p>
                   <figure>
-                     <graphic url="help/images/about.png"/>
+                     <graphic url="images/about.png"/>
                      <head><term type="ediromGui" key="view.desktop.TaskBar_about"/></head>
                   </figure>
                   <figure>
-                     <graphic url="help/images/help.png"/>
+                     <graphic url="images/help.png"/>
                      <head><term type="ediromGui" key="view.desktop.TaskBar_help"/></head>
                   </figure>
                </div>
@@ -195,8 +195,8 @@
                   However, the existence of the concordances in question depends on the respective edition.
                   If the selected concordance contains further subdivisions, such as sentences, a second drop-down menu will appear for selection.</p>
                <figure>
-                    <graphic url="help/images/concNav_en.png"/>
-                    <graphic url="help/images/concNav2_en.png"/>
+                    <graphic url="images/concNav_en.png"/>
+                    <graphic url="images/concNav2_en.png"/>
                     <head><term type="ediromGui" key="view.desktop.TaskBar_concordanceNav"/> with and without additional drop-down menu.</head>
                 </figure>
                 <p>Below the slider is the button <term type="ediromGui" key="view.window.concordanceNavigator.ConcordanceNavigator_Show"/>. 
@@ -277,54 +277,54 @@
                   </head>
                   <p>The <term type="ediromGui" key="view.window.BottomBar"/> contains the following tools for navigation within the content of the sources:</p>
                   <figure>
-                     <graphic url="help/images/pageView.png"/>
+                     <graphic url="images/pageView.png"/>
                      <head><term type="ediromGui" key="view.window.source.SourceView_PageBasedView"/></head>
                      <p>This switches to page-based navigation of the source.</p>
                   </figure>
                   <figure>
-                     <graphic url="help/images/barView.png"/>
+                     <graphic url="images/barView.png"/>
                      <head><term type="ediromGui" key="view.window.source.SourceView_MeasureBasedView"/></head>
                      <p>switches to <term type="ediromGui" key="Bar"/>-based navigation of the source. When this view is activated,slightly different tools appear in the <term type="ediromGui" key="view.window.BottomBar"/> as in the <term type="ediromGui" key="view.window.source.SourceView_PageBasedView"/> (see descriptions below).</p>
                   </figure>
                   <figure>
-                     <graphic url="help/images/prev-box-next.png"/>
+                     <graphic url="images/prev-box-next.png"/>
                      <head><term type="ediromGui" key="view.window.source.SourceView_PageBasedView_pageSpinner"/> or <term type="ediromGui" key="view.window.source.SourceView_MeasureBasedView_measureSpinner"/></head>
                      <p>The number in the number field shows the current page number (<term type="ediromGui" key="view.window.source.SourceView_PageBasedView"/>) or <term type="ediromGui" key="Bar"/> number (<term type="ediromGui" key="view.window.source.SourceView_MeasureBasedView"/>).
                         Switching to another page or <term type="ediromGui" key="Bar"/> is possible by clicking on the arrow heads or entering a number in the number field.
                         The possible numbers correspond to the source, so they do not always start with 1 and can also contain alphanumeric characters.</p>
                   </figure>
                   <figure>
-                     <graphic url="help/images/slider.png"/>
+                     <graphic url="images/slider.png"/>
                      <head><term type="ediromGui" key="view.window.source.SourceView_PageBasedView"/>, <term type="ediromGui" key="view.window.source.SourceView_zoomSlider"/></head>
                      <p>This sets the zoom level for the displayed source.</p>
                   </figure>
                   <figure>
-                     <graphic url="help/images/SourceView_measureBasedCombo.png"/>
+                     <graphic url="images/SourceView_measureBasedCombo.png"/>
                      <head><term type="ediromGui" key="view.window.source.SourceView_MeasureBasedView"/>, <term type="ediromGui" key="view.window.source.SourceView_measureBasedCombo"/></head>
                      <p>The movement whose <term type="ediromGui" key="Bar"/>s should be displayed can be selected.</p>
                   </figure>
                   <figure>
-                     <graphic url="help/images/SourceView_measureBasedRange.png"/>
+                     <graphic url="images/SourceView_measureBasedRange.png"/>
                      <head><term type="ediromGui" key="view.window.source.SourceView_MeasureBasedView"/>, <term type="ediromGui" key="view.window.source.SourceView_measureBasedRange"/></head>
                      <p>Enter a <term type="ediromGui" key="Bar"/> range through which you want to scroll.</p>
                   </figure>
                   <figure>
-                     <graphic url="help/images/selectVoices.png"/>
+                     <graphic url="images/selectVoices.png"/>
                      <head><term type="ediromGui" key="view.window.source.SourceView_MeasureBasedView"/>, <term type="ediromGui" key="view.window.source.SourceView_MeasureBasedView_selectVoices"/></head>
                      <p>Individual parts can be selected. This tool is only available when different parts are in the encoding.</p>
                   </figure>
                   <figure>
-                     <graphic url="help/images/measureNumbers.png"/>
+                     <graphic url="images/measureNumbers.png"/>
                      <head><term type="ediromGui" key="view.desktop.TaskBar_measureNumbers"/></head>
                      <p>The <term type="ediromGui" key="Bar"/>s of facsimiles and editions are usually provided with numbers; these can be shown and hidden in the current window using this button. The window's setting will be overridden when the global <term type="ediromGui" key="view.desktop.TaskBar_measureNumbers"/> button is used.</p>
                   </figure>
                   <figure>
-                     <graphic url="help/images/annotations.png"/>
+                     <graphic url="images/annotations.png"/>
                      <head><term type="ediromGui" key="view.desktop.TaskBar_annotations"/></head>
                     <p>With the speech bubble button you can <term type="ediromGui" key="view.desktop.TaskBar_annotations"/> for the current window. The window's setting will be overridden when the global <term type="ediromGui" key="view.desktop.TaskBar_annotations"/> button is used.</p>
                   </figure>
                   <figure>
-                     <graphic url="help/images/zoom-fit.png"/>
+                     <graphic url="images/zoom-fit.png"/>
                      <head><term type="ediromGui" key="view.window.source.SourceView_fitView"/></head>
                      <p>This resizes the current source to fit the window.</p>
                   </figure>
@@ -396,23 +396,23 @@
                </p><lb/>
                <p>The <term type="ediromGui" key="view.window.BottomBar"/> contains the following tools.</p>
                <figure>
-                  <graphic url="help/images/view-list-details-symbolic.png"/>
+                  <graphic url="images/view-list-details-symbolic.png"/>
                   <head>(Return to) <term type="ediromGui" key="view.window.AnnotationView_ListView"/></head>
                </figure>
                <figure>
-                  <graphic url="help/images/go-previous.png"/>
+                  <graphic url="images/go-previous.png"/>
                   <head><term type="ediromGui" key="view.window.AnnotationView_PreviousAnnotation"/> from the annotation list.</head>
                </figure>
                <figure>
-                  <graphic url="help/images/go-next.png"/>
+                  <graphic url="images/go-next.png"/>
                   <head><term type="ediromGui" key="view.window.AnnotationView_NextAnnotation"/> from the annotation list.</head>
                </figure>
                <figure>
-                  <graphic url="help/images/openAllWindows.png"/>
+                  <graphic url="images/openAllWindows.png"/>
                   <head><term type="ediromGui" key="view.window.AnnotationView_OpenAll"/>: Opens the detailed view of all sources related to the currently selected annotation.</head>
                </figure>
                <figure>
-                  <graphic url="help/images/closeAllWindows.png"/>
+                  <graphic url="images/closeAllWindows.png"/>
                   <head><term type="ediromGui" key="view.window.AnnotationView_CloseAll"/>: Only available if <term type="ediromGui" key="view.window.AnnotationView_OpenAll"/> was previously run.</head>
                </figure>
             </div>
@@ -428,7 +428,7 @@
                  The use of these options depends on the edition guidelines (e.g. the categories that were actually used). 
                  Therefore, the following description should not be viewed as a complete documentation, but rather as an introduction to the basic concepts of this consideration.</p>
               <figure>
-                 <graphic url="help/images/annotationOverview.png"/>
+                 <graphic url="images/annotationOverview.png"/>
                  <head>An example screenshot of an annotation icon, showing the tooltip of a single annotation.</head>
               </figure>
               
@@ -438,15 +438,15 @@
                  <p>A <term type="ediromGui" key="view.window.AnnotationView_Priority"/> gives an indication of the importance of the annotation.
                     The visualization of the <term type="ediromGui" key="view.window.AnnotationView_Priority"/> in the <ptr target="#facsimileView"/> is achieved by color coding the symbols:</p>
                  <figure>
-                    <graphic url="help/images/annotGeneric1.png"/>
+                    <graphic url="images/annotGeneric1.png"/>
                     <p><hi rend="italic">Priority 1</hi> Annotations refer to the edition-specific key issues and are marked red.</p>
                  </figure>
                  <figure>
-                    <graphic url="help/images/annotGeneric2.png"/>
+                    <graphic url="images/annotGeneric2.png"/>
                     <p><hi rend="italic">Priority 2</hi> Annotations refer to important aspects of the edition that are not of the utmost importance for the edition and are marked orange.</p>
                  </figure>
                  <figure>
-                    <graphic url="help/images/annotGeneric3.png"/>
+                    <graphic url="images/annotGeneric3.png"/>
                     <p><hi rend="italic">Priority 3</hi> Annotations contain editorial observations that are normally only of interest to the document sources. These annotations are marked yellow.</p>
                  </figure>
               </div>
@@ -469,9 +469,9 @@
                           <cell>score</cell>
                           <cell>
                              <figure>
-                                <graphic url="help/images/annotNotation1.png"/>
-                                <graphic url="help/images/annotNotation2.png"/>
-                                <graphic url="help/images/annotNotation3.png"/>
+                                <graphic url="images/annotNotation1.png"/>
+                                <graphic url="images/annotNotation2.png"/>
+                                <graphic url="images/annotNotation3.png"/>
                              </figure>
                           </cell>
                        </row>
@@ -479,9 +479,9 @@
                           <cell>Expressive labeling</cell>
                           <cell>
                              <figure>
-                                <graphic url="help/images/annotExpr1.png"/>
-                                <graphic url="help/images/annotExpr2.png"/>
-                                <graphic url="help/images/annotExpr3.png"/>
+                                <graphic url="images/annotExpr1.png"/>
+                                <graphic url="images/annotExpr2.png"/>
+                                <graphic url="images/annotExpr3.png"/>
                              </figure>
                           </cell>
                        </row>
@@ -489,9 +489,9 @@
                           <cell>Choral Text</cell>
                           <cell>
                              <figure>
-                                <graphic url="help/images/annotText1.png"/>
-                                <graphic url="help/images/annotText2.png"/>
-                                <graphic url="help/images/annotText3.png"/>
+                                <graphic url="images/annotText1.png"/>
+                                <graphic url="images/annotText2.png"/>
+                                <graphic url="images/annotText3.png"/>
                              </figure>
                           </cell>
                        </row>
@@ -499,9 +499,9 @@
                           <cell>Combination of different categories</cell>
                           <cell>
                              <figure>
-                                <graphic url="help/images/annotGeneric1.png"/>
-                                <graphic url="help/images/annotGeneric2.png"/>
-                                <graphic url="help/images/annotGeneric3.png"/>
+                                <graphic url="images/annotGeneric1.png"/>
+                                <graphic url="images/annotGeneric2.png"/>
+                                <graphic url="images/annotGeneric3.png"/>
                              </figure>
                           </cell>
                        </row>


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
This will make getHelp process the image addresses in the TEI in a similar way to getText. This change is needed as regular TEI files and the help files will be processed by the same endopoint in API v2.

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Issue: Refs #175 
Frontend PR: https://github.com/Edirom/Edirom-Online-Frontend/pull/209

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
- From the Edirom-Online main repo, build with 
```
export BE_BRANCH=175-uniform-getText-getHelp
export FE_BRANCH=update-getHelp
docker compose down --volumes --remove-orphans && docker compose build --no-cache && docker compose up
```
- Thest the frontend by going to the help window: all the image should display correctly.
- Test the backend by going to https://edirom.github.io/Edirom-Online-API/#/Other/getHelp and checking visually the response. Look for the image addresses.

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- The addresses in the `<img>` elements now appear as `src="http://localhost:8080/exist/apps/Edirom-Online-Backend/help/images/searchField.png"` in the response instead of `src="/exist/apps/Edirom-Online-Backend/help/images/searchField.png"`. The frontend also needs to be updated.

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- [ x ] I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Backend/blob/develop/CONTRIBUTING.md) document.
- [ x ] All new and existing tests passed.
