### PR TITLE
fix: encode digilib URI parameters

### DIFF
--- a/data/xql/getAnnotationPreviews.xql
+++ b/data/xql/getAnnotationPreviews.xql
@@ -196,8 +196,8 @@ declare function local:getSourceParticipants($participants as xs:string*, $doc a
                 'page': $page,
                 'source': $sourceLabel,
                 'siglum': $siglum,
-                'digilibBaseParams': $digilibBaseParams,
-                'digilibSizeParams': $digilibSizeParams,
+                'digilibBaseParams': encode-for-uri($digilibBaseParams),
+                'digilibSizeParams': encode-for-uri($digilibSizeParams),
                 'hiddenData': $hiddenData,
                 'content': '',
                 'linkUri': $linkUri


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
Uri-encode digilib parameters to fix generation of digilib image server URIs for annotaiton previewa

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
closes https://github.com/Edirom/Edirom-Online-Backend/issues/177

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the inline documentation accordingly.
- [x] I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- [x] I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Backend/blob/develop/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes at [testing](https://github.com/Edirom/Edirom-Online-Backend/tree/develop/testing)
- [ ] All new and existing tests passed.

Please combine with:
https://github.com/Edirom/Edirom-Online-Frontend/pull/215
