### PR TITLE
updates jQuery references in the backend to version 4.0.0

### DIFF
--- a/data/xql/getAudioPlayer.xql
+++ b/data/xql/getAudioPlayer.xql
@@ -73,7 +73,9 @@ return
                 src="../../resources/js/amplitude.min.js"></script>
             <script
                 type="text/javascript"
-                src="../../resources/js/jquery-2.1.4.min.js"></script>
+                src="https://code.jquery.com/jquery-4.0.0.min.js"
+                integrity="sha256-OaVG6prZf4v69dPg6PhVattBXkcOWQB62pdZ3ORyrao="
+                crossorigin="anonymous"></script>
             
             <link
                 rel="stylesheet"

--- a/index.xql
+++ b/index.xql
@@ -75,7 +75,7 @@ let $eoIndexPage :=  <html>
                             <script type="text/javascript" src="resources/js/openseadragon.min.js"/>
                             
                             <!-- **JQUERY** -->
-                            <script type="text/javascript" src="resources/jquery/jquery-2.1.3.js" charset="utf-8"/>
+                            <script type="text/javascript" src="https://code.jquery.com/jquery-4.0.0.min.js" integrity="sha256-OaVG6prZf4v69dPg6PhVattBXkcOWQB62pdZ3ORyrao=" crossorigin="anonymous" charset="utf-8"/>
                             
                             <!-- **ACE** -->
                             <script src="resources/js/ace/ace.js" type="text/javascript" charset="utf-8"/>


### PR DESCRIPTION
## Description, Context and related Issue

Updates jQuery references in the backend to version 4.0.0, consistent with
the frontend update, see Edirom-Online-Frontend: [PR226](https://github.com/Edirom/Edirom-Online-Frontend/pull/226)).

Two separate backend files loaded different outdated jQuery versions:
- index.xql referenced resources/jquery/jquery-2.1.3.js (local file that did
  not exist — jQuery was silently not loading in this context)
- getAudioPlayer.xql referenced resources/js/jquery-2.1.4.min.js

Both are replaced with a CDN reference to 4.0.0.

Refs https://github.com/Edirom/Edirom-Online-Frontend/issues/187

## How Has This Been Tested?

- Docker container rebuilt with updated backend
- Manual test: AudioPlayer opened and functional

## Types of changes
- Improvement 

## Overview
- I have performed a self-review of my code, according to the style guide
- I have read the CONTRIBUTING document.
- All new and existing tests passed.