### PR TITLE
Update current test setup

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -87,7 +87,6 @@ jobs:
         run: ant xqunit-tests
       - name: Run regression tests
         run: ant regression-tests
-        if: ${{ github.event_name == 'pull_request' }}
       - name: Tear down Docker
         run: ant test-cleanup
         if: ${{ always() }}

--- a/tests/XQSuite/eutil-tests.xqm
+++ b/tests/XQSuite/eutil-tests.xqm
@@ -43,8 +43,8 @@ declare
 declare
     %test:arg("uri")                %test:assertEmpty
     %test:arg("uri", "")            %test:assertEmpty
-    %test:args("foo")               %test:assertEmpty
-    %test:args("https://edirom.de") %test:assertXPath("/html")
+    %test:args("foo")               %test:assertError (: non-db URIs are blocked :)
+    %test:args("https://edirom.de") %test:assertError (: non-db URIs are blocked :)
     %test:args("xmldb:exist://db/apps/Edirom-Online-Backend/data/locale/edirom-lang-de.xml")    %test:assertXPath("/langFile")
     %test:args("/db/apps/Edirom-Online-Backend/data/locale/edirom-lang-de.xml")                 %test:assertXPath("/langFile")
     function eut:test-getDoc($uri as xs:string?) as document-node()? {

--- a/tests/ant-tests.xml
+++ b/tests/ant-tests.xml
@@ -32,7 +32,11 @@
         
         <!-- Parse the results and check for errors -->
         <exec executable="xmllint" outputproperty="error.count">
-            <arg line="--xpath &quot;count(//testcase[failure])&quot; ${xqunit-tests-results.file}"/>
+            <!--
+                "A test case is considered successful (passed) unless there is another result element underneath it."
+                https://github.com/testmoapp/junitxml
+            -->
+            <arg line="--xpath &quot;count(//testcase[*])&quot; ${xqunit-tests-results.file}"/>
         </exec>
         
         <!-- Load the results and output to the logs -->


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
I found two issues with the current test setup, one major and one minor:

# Major issue
The XQSuite test had not been flagged as failing although not all tests were successful. This was due to a wrong XPath expression and got fixed in c02306c56ba49e029a9e95e0da9f4111a5a2ed5f.
Also the tests needed to be updated: 61adfe9423e61df83b67917f38210470ce8b6dbb

# Minor issue
The regression tests were not running on pushes to the dev branch but only on PRs. This originated from the test setup were the results were coming from a Edirom Online Backend development instance. Now that the results are hard coded, the tests should be run on every push/pr: 7e73d29baa9928eed4bd4a68282b1d3686474e10


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
```sh
docker build -t eol:backend .
ant docker-run-test-image -Dtest.image=eol:backend  
ant regression-tests
ant xqunit-tests
```

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)
- Improvement

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the inline documentation accordingly.
- [x] I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- [x] I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Backend/blob/develop/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes at [tests](https://github.com/Edirom/Edirom-Online-Backend/tree/develop/tests)
- [x] All new and existing tests passed.
