### PR TITLE
bug/70 considers label if present, falling back to n

### DIFF
--- a/data/xql/getAnnotationPreviews.xql
+++ b/data/xql/getAnnotationPreviews.xql
@@ -400,39 +400,49 @@ declare function local:getItemLabel($elems as element()*) as xs:string {
                     else
                         ()
 
+            let $item1Label := if ($items[1]/@label) then $items[1]/string(@label) else $items[1]/string(@n)
+
             let $itemLabelMultiRestSensitive :=
                 if ($items[1]//mei:multiRest) then
-                    ($items[1]/@n || '–' || number($items[1]/@n) + number($items[1]//mei:multiRest/@num) - 1)
+                    ($item1Label || '–' || number($items[1]/@n) + number($items[1]//mei:multiRest/@num) - 1)
                 else
-                    $items[1]/@n
+                    $item1Label
 
             return
                 if (local-name($items[1]) eq 'measure') then (
                     if (count($items) gt 1) then
-                        (eutil:getLanguageString('Bars_from_to', ($items[1]/@n, $items[last()]/@n), $language))
+                        (eutil:getLanguageString('Bars_from_to', ($item1Label, if ($items[last()]/@label) then $items[last()]/string(@label) else $items[last()]/string(@n)), $language))
                     else
                         (eutil:getLanguageString('Bar_n', $itemLabelMultiRestSensitive, $language))
                 ) else if (local-name($items[1]) eq 'staff') then (: TODO: $itemLabelMultiRestSensitive also for staffs? :) (
                     if (count($items) gt 1) then (
-                        let $measureNs := distinct-values($items/ancestor::mei:measure/@n)
+                        let $measureLabels := distinct-values(
+                            for $m in $items/ancestor::mei:measure
+                            return if ($m/@label) then $m/string(@label) else $m/string(@n)
+                        )
 
                         let $label :=
-                            if (count($measureNs) gt 1) then
-                                (concat(eutil:getLanguageString('Bars', (), $lang), ' ', $measureNs[1], '-', $measureNs[last()]))
+                            if (count($measureLabels) gt 1) then
+                                (concat(eutil:getLanguageString('Bars', (), $lang), ' ', $measureLabels[1], '-', $measureLabels[last()]))
                             else (
-                                concat(eutil:getLanguageString('Bar', (), $lang), ' ', $measureNs[1])
+                                concat(eutil:getLanguageString('Bar', (), $lang), ' ', $measureLabels[1])
                             )
 
                         return
                             concat($label, ' (', string-join($items/preceding::mei:staffDef[@n = $items[1]/@n][1]/@label.abbr, ', '), ')')
-                    ) else
-                        (concat(eutil:getLanguageString('Bar', (), $lang), ' ', $items[1]/ancestor::mei:measure/@n, ' (', $items[1]/preceding::mei:staffDef[@n = $items[1]/@n][1]/@label.abbr, ')'))
+                    ) else (
+                        let $m := $items[1]/ancestor::mei:measure
+                        return
+                            concat(eutil:getLanguageString('Bar', (), $lang), ' ', (if ($m/@label) then $m/string(@label) else $m/string(@n)), ' (', $items[1]/preceding::mei:staffDef[@n = $items[1]/@n][1]/@label.abbr, ')')
+                    )
 
                 ) else if (local-name($items[1]) eq 'zone') then (
                     if (count($items) gt 1) then (
                         (:Dieser Fall sollte nicht vorkommen, da freie zones nicht zusammengefasst werden dürfen:)
                     ) else (
-                        concat(eutil:getLanguageString('Detail', (), $lang), ' (', eutil:getLanguageString('Abbrev_page', (), $lang), ' ', $items[1]/parent::mei:surface/@n, ')')
+                        let $surf := $items[1]/parent::mei:surface
+                        return
+                            concat(eutil:getLanguageString('Detail', (), $lang), ' (', eutil:getLanguageString('Abbrev_page', (), $lang), ' ', (if ($surf/@label) then $surf/string(@label) else $surf/string(@n)), ')')
                     )
                 ) else ()
         ), ' ')


### PR DESCRIPTION
## Description, Context and related Issue

Annotation previews now use `@label` as display value for measures and surfaces,
falling back to `@n` when no `@label` is present. This is consistent with the
behavior introduced for surfaces in PR #85 (issue #84) and the documented
convention in the [data-creation-workflow](https://github.com/Edirom/Edirom-Online/blob/2a3012444fff4360fa0831f84e5cda0e07ee1771/docs/data-creation-workflow.md?plain=1#L92).

Closes https://github.com/Edirom/Edirom-Online-Backend/issues/70

## How Has This Been Tested?

- Rebuilt Docker container from this branch
- Opened an edition with annotations on measures that have `@label` attributes --> EditionExample, source Autograph (Ms)
- Verified that annotation previews display `@label` values instead of `@n` --> `@label=5 @n=6`, now shows "Bar 5" (instead of "Bar 6")
- Verified that editions without `@label` still display `@n` correctly (fallback) --> deleted label to check

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Overview
- I have performed a self-review of my code, according to the style guide
- I have read the CONTRIBUTING document.
- All new and existing tests passed.

Bar: 6 (did read from `@n`)
<img width="1831" height="835" alt="Bildschirmfoto 2026-07-01 um 09 42 37" src="https://github.com/user-attachments/assets/e227107a-fa02-493d-8ad7-9f88c44a3a06" />

Bar: 5 (now reads from `@label`)
<img width="1897" height="805" alt="Bildschirmfoto 2026-07-01 um 09 43 51" src="https://github.com/user-attachments/assets/e4fd21ea-7310-4e9c-b554-b8421636ae1d" />
