### PR TITLE
reverted to old lang keys for ediromCategory and ediromPriority

### DIFF
--- a/data/locale/edirom-lang-de.xml
+++ b/data/locale/edirom-lang-de.xml
@@ -77,9 +77,9 @@
         <entry key="view.window.AnnotationView_Title" value="Anmerkungen"/>
         <entry key="view.window.AnnotationView_No" value="Nr."/>
         <entry key="view.window.AnnotationView_TitleLabel" value="Titel"/>
-        <entry key="ediromCategory_multiple" value="Kategorien"/>
-        <entry key="ediromCategory" value="Kategorie"/>
-        <entry key="ediromPriority" value="Priorität"/>
+        <entry key="view.window.AnnotationView_Categories" value="Kategorien"/>
+        <entry key="view.window.AnnotationView_Category" value="Kategorie"/>
+        <entry key="view.window.AnnotationView_Priority" value="Priorität"/>
         <entry key="view.window.AnnotationView_Participants" value="Subjekte"/>
         <entry key="view.window.AnnotationView_Source" value="Quelle"/>
         <entry key="view.window.AnnotationView_Sources" value="Quellen"/>

--- a/data/locale/edirom-lang-de.xml
+++ b/data/locale/edirom-lang-de.xml
@@ -80,6 +80,9 @@
         <entry key="view.window.AnnotationView_Categories" value="Kategorien"/>
         <entry key="view.window.AnnotationView_Category" value="Kategorie"/>
         <entry key="view.window.AnnotationView_Priority" value="Priorität"/>
+        <entry key="ediromCategory_multiple" value="Kategorien"/>
+        <entry key="ediromCategory" value="Kategorie"/>
+        <entry key="ediromPriority" value="Priorität"/>
         <entry key="view.window.AnnotationView_Participants" value="Subjekte"/>
         <entry key="view.window.AnnotationView_Source" value="Quelle"/>
         <entry key="view.window.AnnotationView_Sources" value="Quellen"/>

--- a/data/locale/edirom-lang-en.xml
+++ b/data/locale/edirom-lang-en.xml
@@ -77,9 +77,9 @@
         <entry key="view.window.AnnotationView_Title" value="Annotations"/>
         <entry key="view.window.AnnotationView_No" value="No."/>
         <entry key="view.window.AnnotationView_TitleLabel" value="Title"/>
-        <entry key="ediromCategory_multiple" value="Categories"/>
-        <entry key="ediromCategory" value="Category"/>
-        <entry key="ediromPriority" value="Priority"/>
+        <entry key="view.window.AnnotationView_Categories" value="Categories"/>
+        <entry key="view.window.AnnotationView_Category" value="Category"/>
+        <entry key="view.window.AnnotationView_Priority" value="Priority"/>
         <entry key="view.window.AnnotationView_Participants" value="Participants"/>
         <entry key="view.window.AnnotationView_Source" value="Source"/>
         <entry key="view.window.AnnotationView_Sources" value="Sources"/>

--- a/data/locale/edirom-lang-en.xml
+++ b/data/locale/edirom-lang-en.xml
@@ -80,6 +80,9 @@
         <entry key="view.window.AnnotationView_Categories" value="Categories"/>
         <entry key="view.window.AnnotationView_Category" value="Category"/>
         <entry key="view.window.AnnotationView_Priority" value="Priority"/>
+        <entry key="ediromCategory_multiple" value="Categories"/>
+        <entry key="ediromCategory" value="Category"/>
+        <entry key="ediromPriority" value="Priority"/>
         <entry key="view.window.AnnotationView_Participants" value="Participants"/>
         <entry key="view.window.AnnotationView_Source" value="Source"/>
         <entry key="view.window.AnnotationView_Sources" value="Sources"/>

--- a/data/xql/getAnnotation.xql
+++ b/data/xql/getAnnotation.xql
@@ -323,7 +323,7 @@ let $participants := annotation:getParticipants($annot)
 
 let $priority := local:getPriority($annot)
 
-let $priorityLabel := eutil:getLanguageString('view.window.AnnotationView_ediromPriority', (), $lang)
+let $priorityLabel := eutil:getLanguageString('view.window.AnnotationView_Priority', (), $lang)
 
 let $categories := local:getCategories($annot)
 

--- a/data/xql/getAnnotationMeta.xql
+++ b/data/xql/getAnnotationMeta.xql
@@ -51,14 +51,14 @@ let $priorityLabel := switch ($priority)
          return
              ()
      default return
-         eutil:getLanguageString('ediromPriority', ()) || ' (legacy)'
+         eutil:getLanguageString('view.window.AnnotationView_Priority', ()) || ' (legacy)'
 
  let $categories := annotation:get-category-labels-as-sequence($annot)
  let $categoriesLabel :=
     switch (count($categories))
         case 0 return ()
         case 1 return
-             eutil:getLanguageString('ediromCategory', ()) || ' (legacy)'
+             eutil:getLanguageString('view.window.AnnotationView_Category', ()) || ' (legacy)'
         default return
          eutil:getLanguageString('view.window.AnnotationView_Categories', ()) || ' (legacy)'
 

--- a/data/xql/getAnnotationMeta.xql
+++ b/data/xql/getAnnotationMeta.xql
@@ -60,7 +60,7 @@ let $priorityLabel := switch ($priority)
         case 1 return
              eutil:getLanguageString('ediromCategory', ()) || ' (legacy)'
         default return
-         eutil:getLanguageString('ediromCategory_multiple', ()) || ' (legacy)'
+         eutil:getLanguageString('view.window.AnnotationView_Categories', ()) || ' (legacy)'
 
 (: TODO deprecate above categories and priorities fields with Edirom-Online-API 2.0.0 :)
 


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
This reverts language keys to previous state of keys to keep them backwards-compatible and consistent.