### PR TITLE
regression/modernize-index-configuration

### DIFF
--- a/index/collection.xconf
+++ b/index/collection.xconf
@@ -1,6 +1,5 @@
 <collection xmlns="http://exist-db.org/collection-config/1.0">
     <index xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xlink="http://www.w3.org/1999/xlink">
-        <fulltext default="none" attributes="no"/>
         <lucene>
             <analyzer class="org.apache.lucene.analysis.standard.StandardAnalyzer"/>
             <analyzer id="ws" class="org.apache.lucene.analysis.core.WhitespaceAnalyzer"/>

--- a/index/collection.xconf
+++ b/index/collection.xconf
@@ -1,5 +1,5 @@
 <collection xmlns="http://exist-db.org/collection-config/1.0">
-    <index xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <index xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema">
         <lucene>
             <analyzer class="org.apache.lucene.analysis.standard.StandardAnalyzer"/>
             <analyzer id="ws" class="org.apache.lucene.analysis.core.WhitespaceAnalyzer"/>
@@ -19,15 +19,17 @@
             <text qname="mei:title" boost="2.0"/>
             <text qname="mei:annot"/>
         </lucene>
-        <create qname="@type" type="xs:string"/>
-        <create qname="@plist" type="xs:string"/>
-        <create qname="@facs" type="xs:string"/>
-        <create qname="@n" type="xs:string"/>
-        <create qname="@num" type="xs:integer"/>
-        <create qname="@xml:lang" type="xs:string"/>
-        <create qname="@xml:id" type="xs:string"/>
-        <create qname="@id" type="xs:string"/>
-        <create qname="@key" type="xs:string"/>
+        <range>
+            <create qname="@type" type="xs:string"/>
+            <create qname="@plist" type="xs:string"/>
+            <create qname="@facs" type="xs:string"/>
+            <create qname="@n" type="xs:string"/>
+            <create qname="@num" type="xs:integer"/>
+            <create qname="@xml:lang" type="xs:string"/>
+            <create qname="@xml:id" type="xs:string"/>
+            <create qname="@id" type="xs:string"/>
+            <create qname="@key" type="xs:string"/>
+        </range>
     </index>
     <triggers>
         <trigger class="org.exist.extensions.exquery.restxq.impl.RestXqTrigger"/>

--- a/tests/regressionTests/expected-results/f16ac3b03c626c0b2ea61af0b97d4250
+++ b/tests/regressionTests/expected-results/f16ac3b03c626c0b2ea61af0b97d4250
@@ -1,5 +1,5 @@
 {
-  "count" : 226,
+  "count" : 254,
   "priorities" : [ {
     "id" : "ediromAnnotPrio1",
     "name" : "1"


### PR DESCRIPTION
## Description, Context and related Issue

In #186 the regression tests surfaced some bugs concerning annotation counts and retrieval depending on very long `@plist` match or contains queries.


## Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Improvement
- Refactoring

## Important Changes

* Removes the dead <fulltext> line, because that was for the old eXist fulltext index dropped in v3.0.0
* Moves away from the legacy range index, which has a string length limit that would drop long strings completely from the index (as observed in the context of #186) and result in false-false results.