### PR TITLE
Making dynamic taxonomies backwards-compatible

### DIFF
--- a/data/xql/getAnnotationInfos.xql
+++ b/data/xql/getAnnotationInfos.xql
@@ -30,6 +30,7 @@ declare option output:media-type "application/json";
 declare variable $uri := request:get-parameter('uri', '');
 declare variable $edition := request:get-parameter('edition', '');
 declare variable $lang := request:get-parameter('lang', '');
+declare variable $mode := request:get-parameter('mode', '');
 
 
 (: FUNCTION DECLARATIONS =================================================== :)
@@ -127,15 +128,29 @@ let $prios := array {
         }
 }
 
-let $taxonomiesArray :=
-    annotation:get-referenced-categories-as-taxonomy-array($annots, ($mei, $editionCollection), $lang)
+let $baseMap := map {
+    (: TODO deprecate categories field with Edirom-Online-API 2.0.0 :)
+    'categories': $categories,
+    (: TODO deprecate priorities field with Edirom-Online-API 2.0.0 :)
+    'priorities': $prios,
+    'count': count($annots)    
+}
 
+
+let $taxonomiesArray := annotation:get-referenced-categories-as-taxonomy-array($annots, ($mei, $editionCollection), $lang)
+
+let $taxonomiesMap := map {
+    'taxonomies': $taxonomiesArray
+}
+
+(: Return the appropriate result based on the mode :)
 return
-    map {
-        (: TODO deprecate categories field with Edirom-Online-API 2.0.0 :)
-        'categories': $categories,
-        (: TODO deprecate priorities field with Edirom-Online-API 2.0.0 :)
-        'priorities': $prios,
-        'count': count($annots),
-        'taxonomies': $taxonomiesArray
-    }
+    if($mode eq 'taxonomies') then (            
+        map:merge((
+            $baseMap,
+            $taxonomiesMap
+        ))
+    )
+    else (
+        $baseMap
+    )

--- a/data/xql/getAnnotationMeta.xql
+++ b/data/xql/getAnnotationMeta.xql
@@ -36,6 +36,7 @@ declare option output:media-type "text/html";
 let $lang := request:get-parameter('lang', '')
 let $edition := request:get-parameter('edition', '')
 let $uri := request:get-parameter('uri', '')
+let $mode := request:get-parameter('mode', '')
 let $docUri := substring-before($uri, '#')
 let $internalId := substring-after($uri, '#')
 let $doc := eutil:getDoc($docUri)
@@ -45,26 +46,33 @@ let $participants := annotation:getParticipants($annot)
 
 (: TODO deprecate below categories and priorities fields with Edirom-Online-API 2.0.0 :)
 let $hideLegacyFields := xs:boolean(edition:getPreference('annotation_hide_legacy_fields', $edition))
+let $legacyStringSuffix := if($mode eq 'taxonomies') then ' (legacy)' else ''
 let $priority := annotation:getPriorityLabel($annot)
 let $priorityLabel := switch ($priority)
      case ""
          return
              ()
      default return
-         eutil:getLanguageString('view.window.AnnotationView_Priority', ()) || ' (legacy)'
+         eutil:getLanguageString('view.window.AnnotationView_Priority', ()) || $legacyStringSuffix
 
  let $categories := annotation:get-category-labels-as-sequence($annot)
  let $categoriesLabel :=
     switch (count($categories))
         case 0 return ()
         case 1 return
-             eutil:getLanguageString('view.window.AnnotationView_Category', ()) || ' (legacy)'
+             eutil:getLanguageString('view.window.AnnotationView_Category', ()) || $legacyStringSuffix
         default return
-         eutil:getLanguageString('view.window.AnnotationView_Categories', ()) || ' (legacy)'
+         eutil:getLanguageString('view.window.AnnotationView_Categories', ()) || $legacyStringSuffix
 
 (: TODO deprecate above categories and priorities fields with Edirom-Online-API 2.0.0 :)
 
-let $taxonomiesArray := annotation:get-referenced-categories-as-taxonomy-array($annot, $doc, $lang)
+let $taxonomiesArray := if($mode eq 'taxonomies') 
+    then 
+        (: return taxonomy array :)
+        annotation:get-referenced-categories-as-taxonomy-array($annot, $doc, $lang) 
+    else 
+        (: return empty array :)
+        array {}
 
 let $sigla := source:getSiglaAsArray($participants)
 let $siglaLabel := switch (count($sigla))

--- a/data/xql/getAnnotations.xql
+++ b/data/xql/getAnnotations.xql
@@ -36,8 +36,8 @@ declare option output:media-type "application/json";
 (: VARIABLE DECLARATIONS =================================================== :)
 
 declare variable $EDITION := request:get-parameter('edition', '');
-
 declare variable $URI := request:get-parameter('uri', '');
+declare variable $MODE := request:get-parameter('mode', '');
 
 
 (: QUERY BODY ============================================================= :)
@@ -50,7 +50,7 @@ let $uri :=
 
 let $doc := eutil:getDoc($uri)
 
-let $annotations := annotation:annotationsToJSON($uri, $EDITION)
+let $annotations := annotation:annotationsToJSON($uri, $EDITION, $MODE)
 
 let $annotationFields := distinct-values(for $a in $annotations return map:keys($a))
 
@@ -65,12 +65,27 @@ let $emptyFields :=
 let $baseFields := ('id', 'title', 'categories', 'priority', 'pos', 'sigla')
 let $hasTaxonomyFields := some $f in $annotationFields satisfies not($f = $baseFields)
 
+
+let $baseMap := map {
+    'success': true(),
+    'total': count($doc//mei:annot[@type = 'editorialComment']),
+    'annotations': array {$annotations}
+}
+
+let $taxonomiesMap := map {
+    'fields': $annotationFields,
+    'emptyFields': $emptyFields,
+    'legacyFields': array { if ($hasTaxonomyFields) then ('categories', 'priority') else () }
+} 
+
+(: Return the appropriate result based on the mode :)
 return
-    map {
-        'success': true(),
-        'total': count($doc//mei:annot[@type = 'editorialComment']),
-        'annotations': array {$annotations},
-        'fields': $annotationFields,
-        'emptyFields': $emptyFields,
-        'legacyFields': array { if ($hasTaxonomyFields) then ('categories', 'priority') else () }
-    }
+    if($MODE eq 'taxonomies') then (            
+        map:merge((
+            $baseMap,
+            $taxonomiesMap
+        ))
+    )
+    else (
+        $baseMap
+    )

--- a/data/xql/getAnnotationsOnPage.xql
+++ b/data/xql/getAnnotationsOnPage.xql
@@ -37,6 +37,14 @@ declare option output:method "json";
 declare option output:media-type "application/json";
 
 
+(: VARIABLE DECLARATIONS =================================================== :)
+
+declare variable $sourceUri := request:get-parameter('uri', '');
+declare variable $edition := request:get-parameter('edition', '');
+declare variable $surfaceId := request:get-parameter('pageId', '');
+declare variable $mode := request:get-parameter('mode', '');
+
+
 (: FUNCTION DECLARATIONS =================================================== :)
 
 (:~
@@ -78,20 +86,34 @@ declare function local:getAnnotations($sourceUriSharp as xs:string, $surfaceId a
         let $svgList as array(*)* := local:getAnnotSVGs($id, $plist.raw, $elems)
         
         let $plist as array(*)* := local:getParticipants($id, $plist.raw, $elems)
+
+        let $baseMap := map {
+            'id': $id,
+            'plist': $plist,
+            'svgList': $svgList,
+            'fn': 'loadLink("' || $uri || '")',
+            'uri': $uri,
+            'priority': $prio,
+            'categories': $cat            
+        }
+
+        let $taxonomiesMap := map {
+            'taxonomyClasses': $taxonomyClasses
+        }
         
         return
-            map {
-                'id': $id,
-                'plist': $plist,
-                'svgList': $svgList,
-                'fn': 'loadLink("' || $uri || '")',
-                'uri': $uri,
-                'priority': $prio,
-                'categories': $cat,
-                'taxonomyClasses': $taxonomyClasses
-            }
+            if($mode eq 'taxonomies') then (            
+                map:merge((
+                    $baseMap,
+                    $taxonomiesMap
+                ))
+            )
+            else (
+                $baseMap
+            )
     }
 };
+
 
 (:~
  : Returns all annotations in all works of an edirom-edition containing references to a list of IDs from one source
@@ -214,15 +236,9 @@ declare function local:getCoordinates($participant as element()) as xs:integer+ 
 
 (: QUERY BODY ============================================================== :)
 
-let $edition := request:get-parameter('edition', '')
-
-let $sourceUri := request:get-parameter('uri', '')
-
 let $sourceUriSharp := concat($sourceUri, '#')
 
 let $mei := eutil:getDoc($sourceUri)
-
-let $surfaceId := request:get-parameter('pageId', '')
 
 let $surface := $mei/id($surfaceId)
 

--- a/data/xql/getChapters.xql
+++ b/data/xql/getChapters.xql
@@ -56,7 +56,7 @@ let $ret as array(*)* :=
             $tei//tei:div1 | $tei//tei:milestone[@unit = 'number'] |
             $tei//tei:div[@type = 'act']
         let $pageId :=
-            if ($mode = 'pageMode') then
+            if ($mode eq 'pageMode') then
                 (substring-after($elem/preceding::tei:pb[1]/@facs, '#'))
             else
                 ('-1')
@@ -111,7 +111,7 @@ let $ret as array(*)* :=
                         else
                             ($label)
                     let $pageId :=
-                        if ($mode = 'pageMode') then
+                        if ($mode eq 'pageMode') then
                             (substring-after($scene/preceding::tei:pb[1]/@facs, '#'))
                         else
                             ('-1')

--- a/data/xqm/annotation.xqm
+++ b/data/xqm/annotation.xqm
@@ -52,13 +52,13 @@ declare function annotation:get-category-label-localized($node) {
  : @param $uri The document to process
  : @return The JSON representation
  :)
-declare function annotation:annotationsToJSON($uri as xs:string, $edition as xs:string) as map(*)* {
+declare function annotation:annotationsToJSON($uri as xs:string, $edition as xs:string, $mode as xs:string) as map(*)* {
     
     let $doc := eutil:getDoc($uri)
     let $annos := $doc//mei:annot[@type = 'editorialComment']
     return
         for $anno in $annos
-        return annotation:toJSON($anno, $edition)
+        return annotation:toJSON($anno, $edition, $mode)
 };
 
 (:~
@@ -67,7 +67,7 @@ declare function annotation:annotationsToJSON($uri as xs:string, $edition as xs:
  : @param $anno The Annotation to process
  : @return The JSON representation
  :)
-declare function annotation:toJSON($anno as element(), $edition as xs:string) as map(*) {
+declare function annotation:toJSON($anno as element(), $edition as xs:string, $mode as xs:string) as map(*) {
 
     let $id := $anno/string(@xml:id)
     let $lang := request:get-parameter('lang', '')
@@ -145,10 +145,15 @@ declare function annotation:toJSON($anno as element(), $edition as xs:string) as
     )
 
     return
-        map:merge((
-            $baseMap,
-            $taxonomiesMap
-        ))
+        if($mode eq 'taxonomies') then (            
+            map:merge((
+                $baseMap,
+                $taxonomiesMap
+            ))
+        )
+        else (
+            $baseMap
+        )
 };
 
 (:~


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
This introduces an optional GET parameter "mode".
If set to "taxonomies" the results of several xql endpoints return a result specific for the dynamic taxonomies feature introduced in https://github.com/Edirom/Edirom-Online-Backend/pull/83

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
refs #186 
related frontend PR: https://github.com/Edirom/Edirom-Online-Frontend/pull/234

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
together with frontend:
(a) frontend's develop branch which makes requests w/o mode param
(b) frontend's ftr/dynamic-taxonomies-backwards-compatible branch which makes requests with mode param

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Improvement
- Refactoring

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the inline documentation accordingly.
- [x] I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- [x] I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Backend/blob/develop/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes at [tests](https://github.com/Edirom/Edirom-Online-Backend/tree/develop/tests)
- [ ] All new and existing tests passed.
